### PR TITLE
Add auto git versions in OHAI message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,9 @@ OWN_HEADERS     = $(foreach dir,$(OWN_SRC_SUBDIRS),$(wildcard $(dir)/*.hpp))
 OWN_CHEADERS    = $(foreach dir,$(OWN_SRC_SUBDIRS),$(wildcard $(dir)/*.h))
 TO_FORMAT       = $(OWN_SOURCES) $(OWN_CSOURCES) $(OWN_HEADERS) $(OWN_CHEADERS)
 
+# Version stuff
+CFLAGS += -D PD_VERSION=\"$(shell git describe --tags --always)\"
+
 # Now set up the flags needed for playd.
 CFLAGS   += -c $(WARNS) $(PKG_CFLAGS) -g -std=$(C_STD)
 CXXFLAGS += -c $(WARNS) $(PKG_CFLAGS) -g -std=$(CXX_STD)

--- a/src/messages.h
+++ b/src/messages.h
@@ -17,7 +17,10 @@
 //
 
 /// Message shown when a client connects to playd.
-const std::string MSG_OHAI = "playd";
+#ifndef PD_VERSION
+#define PD_VERSION "0.0.0"
+#endif
+const std::string MSG_OHAI = "playd " PD_VERSION;
 
 
 //


### PR DESCRIPTION
Pulls in a version string into a PD_VERSION #define by calling `git describe --tags --always`
Closes #55 
