### PR TITLE
Fix various audio bugs

### DIFF
--- a/src/audio/audio.hpp
+++ b/src/audio/audio.hpp
@@ -46,6 +46,9 @@ public:
 		AT_END,  ///< The Audio has ended and can't play without a seek.
 	};
 
+	/// Virtual, empty destructor for Audio.
+	virtual ~Audio() = default;
+
 	//
 	// Control interface
 	//

--- a/src/audio/audio_sink.cpp
+++ b/src/audio/audio_sink.cpp
@@ -184,6 +184,14 @@ void SdlAudioSink::Callback(std::uint8_t *out, int nbytes)
 
 	// First of all, let's find out how many samples are available in total
 	// to give SDL.
+	//
+	// Note: Since we run concurrently with the decoder, which is also
+	// trying to modify the read capacity of the ringbuf (by adding
+	// things), this technically causes a race condition when we try to
+	// read `avail_samples` number of samples later.  Not to fear: the
+	// actual read capacity can only be greater than or equal to
+	// `avail_samples`, as this is the only place where we can *decrease*
+	// it.
 	auto avail_samples = this->ring_buf.ReadCapacity();
 
 	// Have we run out of things to feed?

--- a/src/audio/audio_sink.cpp
+++ b/src/audio/audio_sink.cpp
@@ -76,6 +76,9 @@ SdlAudioSink::SdlAudioSink(const AudioSource &source, int device_id)
 SdlAudioSink::~SdlAudioSink()
 {
 	if (this->device == 0) return;
+
+	// Silence any currently playing audio.
+	SDL_PauseAudioDevice(this->device, SDL_TRUE);
 	SDL_CloseAudioDevice(this->device);
 }
 

--- a/src/audio/audio_sink.cpp
+++ b/src/audio/audio_sink.cpp
@@ -195,10 +195,12 @@ void SdlAudioSink::Callback(std::uint8_t *out, int nbytes)
 	auto avail_samples = this->ring_buf.ReadCapacity();
 
 	// Have we run out of things to feed?
-	if (this->source_out && avail_samples == 0) {
-		// Then we're out too.
-		this->state = Audio::State::AT_END;
+	if (avail_samples == 0) {
+		// Is this a temporary condition, or have we genuinely played
+		// out all we can?  If the latter, we're now out too.
+		if (this->source_out) this->state = Audio::State::AT_END;
 
+		// Don't even bother reading from the ring buffer.
 		memset(out, 0, lnbytes);
 		return;
 	}

--- a/src/audio/audio_sink.cpp
+++ b/src/audio/audio_sink.cpp
@@ -77,8 +77,6 @@ SdlAudioSink::~SdlAudioSink()
 {
 	if (this->device == 0) return;
 	SDL_CloseAudioDevice(this->device);
-
-	SdlAudioSink::CleanupLibrary();
 }
 
 /* static */ void SdlAudioSink::InitLibrary()

--- a/src/audio/audio_sink.hpp
+++ b/src/audio/audio_sink.hpp
@@ -30,6 +30,9 @@ public:
 	/// Type of iterators used in the Transfer() method.
 	using TransferIterator = AudioSource::DecodeVector::iterator;
 
+	/// Virtual, empty destructor for AudioSink.
+	virtual ~AudioSink() = default;
+
 	/**
 	 * Starts the audio stream.
 	 * @see Stop
@@ -121,7 +124,7 @@ public:
 	SdlAudioSink(const AudioSource &source, int device_id);
 
 	/// Destructs an SdlAudioSink.
-	~SdlAudioSink();
+	~SdlAudioSink() override;
 
 	void Start() override;
 	void Stop() override;

--- a/src/audio/audio_source.hpp
+++ b/src/audio/audio_source.hpp
@@ -59,6 +59,9 @@ public:
 	 */
 	AudioSource(const std::string &path);
 
+	/// Virtual, empty destructor for AudioSource.
+	virtual ~AudioSource() = default;
+
 	//
 	// Methods that must be overridden
 	//

--- a/src/audio/audio_system.hpp
+++ b/src/audio/audio_system.hpp
@@ -33,6 +33,9 @@
 class AudioSystem
 {
 public:
+	/// Virtual, empty destructor for AudioSystem.
+	virtual ~AudioSystem() = default;
+
 	/**
 	 * Creates an Audio for a lack of audio.
 	 * @return A unique pointer to a dummy Audio.

--- a/src/player/player.cpp
+++ b/src/player/player.cpp
@@ -102,15 +102,10 @@ CommandResult Player::Load(const std::string &path)
 
 	assert(this->file != nullptr);
 
-	// Silence and bin the current file as soon as possible.
+	// Bin the current file as soon as possible.
 	// This ensures that we don't have any situations where two files are
 	// contending over resources, or the current file spends a second or
 	// two flushing its remaining audio.
-	try {
-		this->file->SetPlaying(false);
-	}
-	catch (NoAudioError) {
-	}
 	this->file = this->audio.Null();
 
 	try {

--- a/src/player/player.cpp
+++ b/src/player/player.cpp
@@ -102,9 +102,15 @@ CommandResult Player::Load(const std::string &path)
 
 	assert(this->file != nullptr);
 
-	// Bin the current file as soon as possible.
+	// Silence and bin the current file as soon as possible.
 	// This ensures that we don't have any situations where two files are
-	// contending over resources.
+	// contending over resources, or the current file spends a second or
+	// two flushing its remaining audio.
+	try {
+		this->file->SetPlaying(false);
+	}
+	catch (NoAudioError) {
+	}
 	this->file = this->audio.Null();
 
 	try {

--- a/src/player/player.cpp
+++ b/src/player/player.cpp
@@ -100,6 +100,13 @@ CommandResult Player::Load(const std::string &path)
 {
 	if (path.empty()) return CommandResult::Invalid(MSG_LOAD_EMPTY_PATH);
 
+	assert(this->file != nullptr);
+
+	// Bin the current file as soon as possible.
+	// This ensures that we don't have any situations where two files are
+	// contending over resources.
+	this->file = this->audio.Null();
+
 	try {
 		assert(this->file != nullptr);
 		this->file = this->audio.Load(path);


### PR DESCRIPTION
* Fixes #81 by making the `Audio`, `AudioSink` (and other `AudioXYZ`) classes have a virtual destructor.  Because of this most wonderful of implicit C++isms, the `SdlAudioSink` destructor __wasn't being called__, causing it to leak its ownership of the audio device!
* Fixes #82 by not reading from the ringbuffer if there is nothing in it.
* Removes a spurious `SDL_Quit` from the destructor, which would have __ruined everything__ had the destructor been called.
* Pauses playback on the device during the destructor, thus making it actually stop instantaneously rather than about a second afterwards.
* Completely destructs one `Audio` before loading another.  This currently means there's a large amount of delay between audio stopping on a `Load` and the `Load` succeeding, so this may need reverting or tweaking later.  A problem is that currently this is needed to prevent two `SdlAudioSink`s from opening the same device.  It'd be nice if we waited until the file loads before killing the device, so maybe the device should be acquired as soon as the first `Play` occurs, there should be a separate `ArmDevice` (or equivalent) method, the `Load` could take ownership of the original `Audio` and kill it when necessary, or `Audio` could be responsible for `Load`ing.