### PR TITLE
Various IO changes and fixes.

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -36,7 +36,7 @@ void NoAudio::Emit(Response::Code code, const ResponseSink *sink, size_t id)
 
 	if (code == Response::Code::STATE) {
 		auto r = Response(Response::Code::STATE).AddArg("Ejected");
-		sink->Respond(id, r);
+		sink->Respond(r, id);
 	}
 }
 
@@ -120,7 +120,7 @@ void PipeAudio::Emit(Response::Code code, const ResponseSink *sink, size_t id)
 			return;
 	}
 
-	sink->Respond(id, r);
+	sink->Respond(r, id);
 }
 
 void PipeAudio::SetPlaying(bool playing)

--- a/src/audio/audio.hpp
+++ b/src/audio/audio.hpp
@@ -89,9 +89,9 @@ public:
 	 * @param sink The ResponseSink to which the response shall be sent.
 	 *   May be nullptr, in which case Emit should be a no-operation.
 	 * @param id The ID of the connection to which the ResponseSink should
-	 *   route the response.  May be 0, for all (broadcast).
+	 *   route the response.  May be 0 (the default), for all (broadcast).
 	 */
-	virtual void Emit(Response::Code code, const ResponseSink *sink, size_t id) = 0;
+	virtual void Emit(Response::Code code, const ResponseSink *sink, size_t id=0) = 0;
 
 	/**
 	 * This Audio's current position.

--- a/src/audio/audio.hpp
+++ b/src/audio/audio.hpp
@@ -88,8 +88,10 @@ public:
 	 * @param response The response to emit, if possible.
 	 * @param sink The ResponseSink to which the response shall be sent.
 	 *   May be nullptr, in which case Emit should be a no-operation.
+	 * @param id The ID of the connection to which the ResponseSink should
+	 *   route the response.  May be 0, for all (broadcast).
 	 */
-	virtual void Emit(Response::Code code, const ResponseSink *sink) = 0;
+	virtual void Emit(Response::Code code, const ResponseSink *sink, size_t id) = 0;
 
 	/**
 	 * This Audio's current position.
@@ -116,7 +118,7 @@ class NoAudio : public Audio
 {
 public:
 	Audio::State Update() override;
-	void Emit(Response::Code code, const ResponseSink *sink) override;
+	void Emit(Response::Code code, const ResponseSink *sink, size_t id) override;
 
 	// The following all raise an exception:
 
@@ -152,7 +154,7 @@ public:
 	void Seek(std::uint64_t position) override;
 	Audio::State Update() override;
 
-	void Emit(Response::Code code, const ResponseSink *sink) override;
+	void Emit(Response::Code code, const ResponseSink *sink, size_t id) override;
 	std::uint64_t Position() const override;
 
 private:

--- a/src/audio/audio.hpp
+++ b/src/audio/audio.hpp
@@ -203,6 +203,23 @@ private:
 
 	/// Transfers as much of the current frame as possible to the sink.
 	void TransferFrame();
+
+	/**
+	 * Determines whether we can broadcast a TIME response.
+	 *
+	 * To prevent spewing massive amounts of TIME responses, we only send a
+	 * broadcast if the number of seconds has changed since the last
+	 * time CanAnnounceTime() was called for the given sink.
+	 *
+	 * This is *not* idempotent.  A CanAnnounceTime(x) less than one second
+	 * before a CanAnnounceTime(x) will _always_ be false.
+	 *
+	 * @param micros The value of the TIME response, in microseconds.
+	 * @param sink The ResponseSink to which a TIME will be broadcast if
+	 *   this returns true.
+	 * @return Whether it is polite to send TIME to the given sink.
+	 */
+	bool CanAnnounceTime(std::uint64_t micros, const ResponseSink *sink);
 };
 
 #endif // PLAYD_AUDIO_HPP

--- a/src/cmd_result.cpp
+++ b/src/cmd_result.cpp
@@ -58,5 +58,5 @@ void CommandResult::Emit(const ResponseSink &sink,
 	// Then, add in the original command words.
 	for (auto &cwd : cmd) r.AddArg(cwd);
 
-	sink.Respond(id, r);
+	sink.Respond(r, id);
 }

--- a/src/cmd_result.cpp
+++ b/src/cmd_result.cpp
@@ -45,8 +45,8 @@ bool CommandResult::IsSuccess() const
 }
 
 void CommandResult::Emit(const ResponseSink &sink,
-			 size_t id,
-                         const std::vector<std::string> &cmd) const
+                         const std::vector<std::string> &cmd,
+			 size_t id) const
 {
 	Response r(CommandResult::TYPE_CODES[static_cast<uint8_t>(this->type)]);
 

--- a/src/cmd_result.cpp
+++ b/src/cmd_result.cpp
@@ -45,6 +45,7 @@ bool CommandResult::IsSuccess() const
 }
 
 void CommandResult::Emit(const ResponseSink &sink,
+			 size_t id,
                          const std::vector<std::string> &cmd) const
 {
 	Response r(CommandResult::TYPE_CODES[static_cast<uint8_t>(this->type)]);
@@ -57,5 +58,5 @@ void CommandResult::Emit(const ResponseSink &sink,
 	// Then, add in the original command words.
 	for (auto &cwd : cmd) r.AddArg(cwd);
 
-	sink.Respond(0, r);
+	sink.Respond(id, r);
 }

--- a/src/cmd_result.cpp
+++ b/src/cmd_result.cpp
@@ -57,5 +57,5 @@ void CommandResult::Emit(const ResponseSink &sink,
 	// Then, add in the original command words.
 	for (auto &cwd : cmd) r.AddArg(cwd);
 
-	sink.Respond(r);
+	sink.Respond(0, r);
 }

--- a/src/cmd_result.hpp
+++ b/src/cmd_result.hpp
@@ -80,9 +80,12 @@ public:
 	 * response code is most appropriate for the failure.
 	 *
 	 * @param sink The ResponseSink to which the response will be sent.
+	 * @param id The connection ID in the sink to which the response will
+	 *   be sent.
 	 * @param cmd The original command that created this CommandResult.
 	 */
 	void Emit(const ResponseSink &sink,
+	          size_t id,
 	          const std::vector<std::string> &cmd) const;
 
 private:

--- a/src/cmd_result.hpp
+++ b/src/cmd_result.hpp
@@ -80,13 +80,13 @@ public:
 	 * response code is most appropriate for the failure.
 	 *
 	 * @param sink The ResponseSink to which the response will be sent.
-	 * @param id The connection ID in the sink to which the response will
-	 *   be sent.
 	 * @param cmd The original command that created this CommandResult.
+	 * @param id The connection ID in the sink to which the response will
+	 *   be sent.  Defaults to 0 (broadcast).
 	 */
 	void Emit(const ResponseSink &sink,
-	          size_t id,
-	          const std::vector<std::string> &cmd) const;
+	          const std::vector<std::string> &cmd,
+	          size_t id=0) const;
 
 private:
 	Type type;       ///< The command result's type.

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -207,7 +207,7 @@ void IoCore::Remove(size_t slot)
 	assert(!this->pool.at(slot - 1));
 }
 
-void IoCore::Respond(size_t id, const Response &response) const
+void IoCore::Respond(const Response &response, size_t id) const
 {
 	if (this->pool.empty()) return;
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -129,7 +129,7 @@ void UvUpdateTimerCallback(uv_timer_t *handle)
 // ConnectionPool
 //
 
-ConnectionPool::ConnectionPool(Player &player) : player(player), connections()
+ConnectionPool::ConnectionPool(Player &player) : player(player), pool()
 {
 }
 
@@ -145,30 +145,73 @@ void ConnectionPool::Accept(uv_stream_t *server)
 		return;
 	}
 
-	this->connections.emplace_back(
-	        new Connection(*this, client, this->player));
+	// We'll want to try and use an existing, empty slot in the connection
+	// pool.  If there aren't any (we've exceeded the maximum-so-far number
+	// of simultaneous connections), we expand the pool.
+	//
+	// If we already have SIZE_MAX-1 simultaneous connections, we bail out.
+	// Since this is at least 65,534, and likely to be 2^32-2 or 2^64-2,
+	// this is incredibly unlikely to happen and probably means someone's
+	// trying to denial-of-service an audio player.
+	//
+	// Why -1?  Because slot 0 in the connection pool is reserved for
+	// broadcasts.
+	if (this->free_list.empty()) {
+		if (this->pool.size() == (SIZE_MAX - 1)) {
+			throw InternalError("too many simultaneous connections");
+		}
 
-	this->player.WelcomeClient(*this->connections.back());
-	client->data = static_cast<void *>(this->connections.back().get());
+		this->pool.emplace_back(nullptr);
+		// This isn't an off-by-one error; slots index from 1.
+		this->free_list.push_back(this->pool.size());
+	}
+
+	assert(!this->free_list.empty());
+	size_t client_slot = this->free_list.back();
+	this->free_list.pop_back();
+
+	// client_slot should be at least 1, because of the above.
+	assert(0 < client_slot);
+	assert(client_slot <= this->pool.size());
+
+	std::unique_ptr<Connection> conn(new Connection(*this, client, this->player, client_slot));
+	client->data = static_cast<void *>(conn.get());
+	this->pool[client_slot - 1] = std::move(conn);
+
+	// The player will already have been told to send responses to the
+	// IoCore, so all it needs to know is the slot.
+	this->player.WelcomeClient(client_slot);
 
 	uv_read_start((uv_stream_t *)client, UvAlloc, UvReadCallback);
 }
 
-void ConnectionPool::Remove(Connection &conn)
+void ConnectionPool::Remove(size_t slot)
 {
-	this->connections.erase(std::remove_if(
-	        this->connections.begin(), this->connections.end(),
-	        [&](const std::unique_ptr<Connection> &p) {
-		        return p.get() == &conn;
-		}));
+	assert(0 < slot && slot <= this->pool.size());
+
+	// Don't remove if it's already a nullptr, because we'd end up with the
+	// slot on the free list twice.
+	if (this->pool.at(slot - 1)) {
+		this->pool[slot - 1] = nullptr;
+		this->free_list.push_back(slot);
+	}
+
+	assert(!this->pool.at(slot - 1));
 }
 
-void ConnectionPool::Respond(const Response &response) const
+void ConnectionPool::Respond(size_t id, const Response &response) const
 {
-	if (this->connections.empty()) return;
+	if (this->pool.empty()) return;
 
-	Debug() << "Sending command:" << response.Pack() << std::endl;
-	for (const auto &conn : this->connections) conn->Respond(response);
+	if (id == 0) {
+		Debug() << "broadcast:" << response.Pack() << std::endl;
+		for (const auto &conn : this->pool) conn->Respond(response);
+	} else {
+		Debug() << "unicast @" << std::to_string(id) << ":" << response.Pack() << std::endl;
+
+		assert(0 < id && id <= this->pool.size());
+		if (this->pool.at(id - 1)) this->pool.at(id - 1)->Respond(response);
+	}
 }
 
 //
@@ -215,17 +258,17 @@ void IoCore::InitAcceptor(const std::string &address, const std::string &port)
 	Debug() << "Listening at" << address << "on" << port << std::endl;
 }
 
-void IoCore::Respond(const Response &response) const
+void IoCore::Respond(size_t id, const Response &response) const
 {
-	this->pool.Respond(response);
+	this->pool.Respond(id, response);
 }
 
 //
 // Connection
 //
 
-Connection::Connection(ConnectionPool &parent, uv_tcp_t *tcp, Player &player)
-    : parent(parent), tcp(tcp), tokeniser(), player(player)
+Connection::Connection(ConnectionPool &parent, uv_tcp_t *tcp, Player &player, size_t id)
+    : parent(parent), tcp(tcp), tokeniser(), player(player), id(id)
 {
 	Debug() << "Opening connection from" << Name() << std::endl;
 }
@@ -285,7 +328,8 @@ std::string Connection::Name()
 	// See comment for above error.
 	if (ne) return "<error@name: " + std::string(gai_strerror(ne)) + ">";
 
-	return host + std::string(":") + serv;
+	auto id = std::to_string(this->id);
+	return id + std::string("!") + host + std::string(":") + serv;
 }
 
 void Connection::Read(ssize_t nread, const uv_buf_t *buf)
@@ -333,5 +377,5 @@ void Connection::RunCommand(const std::vector<std::string> &cmd)
 
 void Connection::Depool()
 {
-	this->parent.Remove(*this);
+	this->parent.Remove(this->id);
 }

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -365,7 +365,7 @@ void Connection::RunCommand(const std::vector<std::string> &cmd)
 	std::cerr << std::endl;
 
 	CommandResult res = this->player.RunCommand(cmd);
-	res.Emit(this->parent, this->id, cmd);
+	res.Emit(this->parent, cmd, this->id);
 }
 
 void Connection::Depool()

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -372,7 +372,7 @@ void Connection::RunCommand(const std::vector<std::string> &cmd)
 	std::cerr << std::endl;
 
 	CommandResult res = this->player.RunCommand(cmd);
-	res.Emit(this->parent, cmd);
+	res.Emit(this->parent, this->id, cmd);
 }
 
 void Connection::Depool()

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -81,7 +81,7 @@ public:
 	 */
 	void Remove(size_t id);
 
-	void Respond(size_t id, const Response &response) const override;
+	void Respond(const Response &response, size_t id=0) const override;
 
 private:
 	/// The period between player updates.

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -92,7 +92,7 @@ private:
 	Player &player;      ///< The player.
 
 	/// The set of connections inside this IoCore.
-	std::vector<std::unique_ptr<Connection>> pool;
+	std::vector<std::shared_ptr<Connection>> pool;
 
 	/// A list of free 1-indexed slots inside pool.
 	/// These slots may be re-used instead of creating a new slot.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,6 +166,13 @@ void ExitWithError(const std::string &msg)
  */
 int main(int argc, char *argv[])
 {
+	// If we don't ignore SIGPIPE, certain classes of connection droppage
+	// will crash our program with it.
+	// TODO(CaptainHayashi): a more rigorous ifndef here.
+#ifndef _MSC_VER
+	signal(SIGPIPE, SIG_IGN);
+#endif
+
 	// This call needs to happen before GetDeviceID, otherwise no device
 	// IDs will be recognised.  (This is why it's here, and not in
 	// SetupAudioSystem.)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -44,28 +44,28 @@ bool Player::Update()
 	if (as == Audio::State::PLAYING) {
 		// Since the audio is currently playing, the position may have
 		// advanced since last update.  So we need to update it.
-		this->file->Emit(Response::Code::TIME, this->sink);
+		this->file->Emit(Response::Code::TIME, this->sink, 0);
 	}
 
 	return this->is_running;
 }
 
-void Player::EmitAllAudioState(const ResponseSink *sink) const
+void Player::EmitAllAudioState(size_t id) const
 {
-	this->file->Emit(Response::Code::FILE, sink);
-	this->file->Emit(Response::Code::TIME, sink);
-	this->file->Emit(Response::Code::STATE, sink);
+	this->file->Emit(Response::Code::FILE, sink, id);
+	this->file->Emit(Response::Code::TIME, sink, id);
+	this->file->Emit(Response::Code::STATE, sink, id);
 }
 
-void Player::WelcomeClient(ResponseSink &client) const
+void Player::WelcomeClient(size_t id) const
 {
-	client.Respond(Response(Response::Code::OHAI).AddArg(MSG_OHAI));
+	this->sink->Respond(id, Response(Response::Code::OHAI).AddArg(MSG_OHAI));
 
 	auto features = Response(Response::Code::FEATURES);
 	for (auto &f : FEATURES) features.AddArg(f);
-	client.Respond(features);
+	this->sink->Respond(id, features);
 
-	this->EmitAllAudioState(&client);
+	this->EmitAllAudioState(id);
 }
 
 void Player::End()
@@ -80,7 +80,7 @@ void Player::End()
 	// Let upstream know that the file ended by itself.
 	// This is needed for auto-advancing playlists, etc.
 	if (this->sink == nullptr) return;
-	this->sink->Respond(Response(Response::Code::END));
+	this->sink->Respond(0, Response(Response::Code::END));
 }
 
 //
@@ -125,7 +125,7 @@ CommandResult Player::Eject()
 {
 	assert(this->file != nullptr);
 	this->file = this->audio.Null();
-	this->file->Emit(Response::Code::STATE, this->sink);
+	this->file->Emit(Response::Code::STATE, this->sink, 0);
 
 	return CommandResult::Success();
 }
@@ -145,7 +145,7 @@ CommandResult Player::Load(const std::string &path)
 	try {
 		assert(this->file != nullptr);
 		this->file = this->audio.Load(path);
-		this->EmitAllAudioState(this->sink);
+		this->EmitAllAudioState(0);
 		assert(this->file != nullptr);
 	} catch (FileError &e) {
 		// File errors aren't fatal, so catch them here.
@@ -187,7 +187,7 @@ CommandResult Player::SetPlaying(bool playing)
 		return CommandResult::Invalid(e.Message());
 	}
 
-	this->file->Emit(Response::Code::STATE, this->sink);
+	this->file->Emit(Response::Code::STATE, this->sink, 0);
 
 	return CommandResult::Success();
 }
@@ -257,5 +257,5 @@ void Player::SeekRaw(std::uint64_t pos)
 	assert(this->file != nullptr);
 
 	this->file->Seek(pos);
-	this->file->Emit(Response::Code::TIME, this->sink);
+	this->file->Emit(Response::Code::TIME, this->sink, 0);
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -44,7 +44,7 @@ bool Player::Update()
 	if (as == Audio::State::PLAYING) {
 		// Since the audio is currently playing, the position may have
 		// advanced since last update.  So we need to update it.
-		this->file->Emit(Response::Code::TIME, this->sink, 0);
+		this->file->Emit(Response::Code::TIME, this->sink);
 	}
 
 	return this->is_running;
@@ -59,11 +59,11 @@ void Player::EmitAllAudioState(size_t id) const
 
 void Player::WelcomeClient(size_t id) const
 {
-	this->sink->Respond(id, Response(Response::Code::OHAI).AddArg(MSG_OHAI));
+	this->sink->Respond(Response(Response::Code::OHAI).AddArg(MSG_OHAI), id);
 
 	auto features = Response(Response::Code::FEATURES);
 	for (auto &f : FEATURES) features.AddArg(f);
-	this->sink->Respond(id, features);
+	this->sink->Respond(features, id);
 
 	this->EmitAllAudioState(id);
 }
@@ -80,7 +80,7 @@ void Player::End()
 	// Let upstream know that the file ended by itself.
 	// This is needed for auto-advancing playlists, etc.
 	if (this->sink == nullptr) return;
-	this->sink->Respond(0, Response(Response::Code::END));
+	this->sink->Respond(Response(Response::Code::END));
 }
 
 //
@@ -125,7 +125,7 @@ CommandResult Player::Eject()
 {
 	assert(this->file != nullptr);
 	this->file = this->audio.Null();
-	this->file->Emit(Response::Code::STATE, this->sink, 0);
+	this->file->Emit(Response::Code::STATE, this->sink);
 
 	return CommandResult::Success();
 }
@@ -187,7 +187,7 @@ CommandResult Player::SetPlaying(bool playing)
 		return CommandResult::Invalid(e.Message());
 	}
 
-	this->file->Emit(Response::Code::STATE, this->sink, 0);
+	this->file->Emit(Response::Code::STATE, this->sink);
 
 	return CommandResult::Success();
 }
@@ -257,5 +257,5 @@ void Player::SeekRaw(std::uint64_t pos)
 	assert(this->file != nullptr);
 
 	this->file->Seek(pos);
-	this->file->Emit(Response::Code::TIME, this->sink, 0);
+	this->file->Emit(Response::Code::TIME, this->sink);
 }

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -144,7 +144,7 @@ public:
 
 	/**
 	 * Sends welcome/current status information to a new client.
-	 * @param id The ID inside the ConnectionPool of the new client.
+	 * @param id The ID of the new client inside the IO system.
 	 */
 	void WelcomeClient(size_t id) const;
 

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -144,10 +144,9 @@ public:
 
 	/**
 	 * Sends welcome/current status information to a new client.
-	 * @param client An IO ResponseSink to which messages to the client
-	 *   should be sent.
+	 * @param id The ID inside the ConnectionPool of the new client.
 	 */
-	void WelcomeClient(ResponseSink &client) const;
+	void WelcomeClient(size_t id) const;
 
 private:
 	/**
@@ -203,13 +202,14 @@ private:
 	void End();
 
 	/**
-	 * Asks the current file to dump all of its state to the given sink.
-	 * @param sink The sink to which the state responses shall be sent.
+	 * Asks the current file to dump all of its state to the connection
+	 * with the given ID.
+	 * @param id The ID of the connection to receive the dump.
 	 * @note This is a pointer, not a reference, so as to allow nullptr
 	 *   (which means no sink is assigned).  When `optional` becomes
 	 *   standard, perhaps use that.
 	 */
-	void EmitAllAudioState(const ResponseSink *sink) const;
+	void EmitAllAudioState(size_t id) const;
 };
 
 #endif // PLAYD_PLAYER_HPP

--- a/src/response.cpp
+++ b/src/response.cpp
@@ -72,7 +72,7 @@ std::string Response::Pack() const
 // ResponseSink
 //
 
-void ResponseSink::Respond(size_t, const Response &) const
+void ResponseSink::Respond(const Response &, size_t) const
 {
 	// By default, do nothing.
 }

--- a/src/response.cpp
+++ b/src/response.cpp
@@ -72,7 +72,7 @@ std::string Response::Pack() const
 // ResponseSink
 //
 
-void ResponseSink::Respond(const Response &) const
+void ResponseSink::Respond(size_t, const Response &) const
 {
 	// By default, do nothing.
 }

--- a/src/response.hpp
+++ b/src/response.hpp
@@ -87,9 +87,12 @@ class ResponseSink
 public:
 	/**
 	 * Outputs a response.
+	 * @param id The ID, if pertinent, of the sub-component of the
+	 *   ResponseSink to receive a Response, or 0, which signifies that the
+	 *   entire sub-component should receive the Response.
 	 * @param response The Response to output.
 	 */
-	virtual void Respond(const Response &response) const;
+	virtual void Respond(size_t id, const Response &response) const;
 };
 
 #endif // PLAYD_IO_RESPONSE_HPP

--- a/src/response.hpp
+++ b/src/response.hpp
@@ -87,12 +87,12 @@ class ResponseSink
 public:
 	/**
 	 * Outputs a response.
+	 * @param response The Response to output.
 	 * @param id The ID, if pertinent, of the sub-component of the
 	 *   ResponseSink to receive a Response, or 0, which signifies that the
-	 *   entire sub-component should receive the Response.
-	 * @param response The Response to output.
+	 *   entire sub-component should receive the Response.  Defaults to 0.
 	 */
-	virtual void Respond(size_t id, const Response &response) const;
+	virtual void Respond(const Response &response, size_t id=0) const;
 };
 
 #endif // PLAYD_IO_RESPONSE_HPP

--- a/src/tests/cmd_result.cpp
+++ b/src/tests/cmd_result.cpp
@@ -31,7 +31,7 @@ SCENARIO("CommandResult's convenience constructors create correct CommandResults
 			std::vector<std::string> cmd({ "OHAI", "testy test" });
 
 			WHEN("Emit(cmd) is called") {
-				c.Emit(d, 0, cmd);
+				c.Emit(d, cmd);
 
 				THEN("the response is OK followed by the command words") {
 					REQUIRE(os.str() == "OK OHAI 'testy test'\n");
@@ -57,7 +57,7 @@ SCENARIO("CommandResult's convenience constructors create correct CommandResults
 			std::vector<std::string> cmd({ "OHAI", "testy test" });
 
 			WHEN("Emit(cmd) is called") {
-				c.Emit(d, 0, cmd);
+				c.Emit(d, cmd);
 
 				THEN("the response is WHAT followed by the failure message and command") {
 					REQUIRE(os.str() == "WHAT 'PEBCAK error' OHAI 'testy test'\n");
@@ -84,7 +84,7 @@ SCENARIO("CommandResult's convenience constructors create correct CommandResults
 			std::vector<std::string> cmd({ "OHAI", "testy test" });
 
 			WHEN("Emit(cmd) is called") {
-				c.Emit(d, 0, cmd);
+				c.Emit(d, cmd);
 
 				THEN("the response is FAIL followed by the failure message") {
 					REQUIRE(os.str() == "FAIL 'lp0 on fire' OHAI 'testy test'\n");

--- a/src/tests/cmd_result.cpp
+++ b/src/tests/cmd_result.cpp
@@ -31,7 +31,7 @@ SCENARIO("CommandResult's convenience constructors create correct CommandResults
 			std::vector<std::string> cmd({ "OHAI", "testy test" });
 
 			WHEN("Emit(cmd) is called") {
-				c.Emit(d, cmd);
+				c.Emit(d, 0, cmd);
 
 				THEN("the response is OK followed by the command words") {
 					REQUIRE(os.str() == "OK OHAI 'testy test'\n");
@@ -57,7 +57,7 @@ SCENARIO("CommandResult's convenience constructors create correct CommandResults
 			std::vector<std::string> cmd({ "OHAI", "testy test" });
 
 			WHEN("Emit(cmd) is called") {
-				c.Emit(d, cmd);
+				c.Emit(d, 0, cmd);
 
 				THEN("the response is WHAT followed by the failure message and command") {
 					REQUIRE(os.str() == "WHAT 'PEBCAK error' OHAI 'testy test'\n");
@@ -84,7 +84,7 @@ SCENARIO("CommandResult's convenience constructors create correct CommandResults
 			std::vector<std::string> cmd({ "OHAI", "testy test" });
 
 			WHEN("Emit(cmd) is called") {
-				c.Emit(d, cmd);
+				c.Emit(d, 0, cmd);
 
 				THEN("the response is FAIL followed by the failure message") {
 					REQUIRE(os.str() == "FAIL 'lp0 on fire' OHAI 'testy test'\n");

--- a/src/tests/dummy_audio.cpp
+++ b/src/tests/dummy_audio.cpp
@@ -38,7 +38,7 @@ void DummyAudio::Emit(Response::Code code, const ResponseSink *sink, size_t id)
 		return;
 	}
 
-	sink->Respond(id, r);
+	sink->Respond(r, id);
 }
 
 void DummyAudio::SetPlaying(bool playing)

--- a/src/tests/dummy_audio.cpp
+++ b/src/tests/dummy_audio.cpp
@@ -23,7 +23,7 @@ DummyAudio::DummyAudio(DummyAudioSystem &sys) : sys(sys)
 {
 }
 
-void DummyAudio::Emit(Response::Code code, const ResponseSink *sink)
+void DummyAudio::Emit(Response::Code code, const ResponseSink *sink, size_t id)
 {
 	if (sink == nullptr) return;
 
@@ -38,7 +38,7 @@ void DummyAudio::Emit(Response::Code code, const ResponseSink *sink)
 		return;
 	}
 
-	sink->Respond(r);
+	sink->Respond(id, r);
 }
 
 void DummyAudio::SetPlaying(bool playing)

--- a/src/tests/dummy_audio.hpp
+++ b/src/tests/dummy_audio.hpp
@@ -63,7 +63,7 @@ public:
 	void Seek(std::uint64_t position) override;
 	Audio::State Update() override;
 
-	void Emit(Response::Code code, const ResponseSink *sink) override;
+	void Emit(Response::Code code, const ResponseSink *sink, size_t id) override;
 	std::uint64_t Position() const override;
 
 private:

--- a/src/tests/dummy_response_sink.cpp
+++ b/src/tests/dummy_response_sink.cpp
@@ -14,7 +14,7 @@ DummyResponseSink::DummyResponseSink(std::ostream &os) : os(os)
 {
 }
 
-void DummyResponseSink::Respond(const Response &response) const
+void DummyResponseSink::Respond(size_t, const Response &response) const
 {
 	this->os << response.Pack() << std::endl;
 }

--- a/src/tests/dummy_response_sink.cpp
+++ b/src/tests/dummy_response_sink.cpp
@@ -14,7 +14,7 @@ DummyResponseSink::DummyResponseSink(std::ostream &os) : os(os)
 {
 }
 
-void DummyResponseSink::Respond(size_t, const Response &response) const
+void DummyResponseSink::Respond(const Response &response, size_t) const
 {
 	this->os << response.Pack() << std::endl;
 }

--- a/src/tests/dummy_response_sink.hpp
+++ b/src/tests/dummy_response_sink.hpp
@@ -23,7 +23,7 @@ public:
 	DummyResponseSink(std::ostream &os);
 
 protected:
-	virtual void Respond(size_t id, const Response &response) const override;
+	virtual void Respond(const Response &response, size_t id=0) const override;
 
 private:
 	/// Reference to the output stream.

--- a/src/tests/dummy_response_sink.hpp
+++ b/src/tests/dummy_response_sink.hpp
@@ -23,7 +23,7 @@ public:
 	DummyResponseSink(std::ostream &os);
 
 protected:
-	virtual void Respond(const Response &response) const override;
+	virtual void Respond(size_t id, const Response &response) const override;
 
 private:
 	/// Reference to the output stream.

--- a/src/tests/no_audio.cpp
+++ b/src/tests/no_audio.cpp
@@ -36,7 +36,7 @@ SCENARIO("NoAudio emits state, but no file or position", "[no-audio]") {
 		WHEN("the NoAudio is asked to emit a STATE") {
 			std::ostringstream os;
 			DummyResponseSink rs(os);
-			n.Emit(Response::Code::STATE, &rs);
+			n.Emit(Response::Code::STATE, &rs, 0);
 
 			THEN("'STATE Ejected' is emitted") {
 				REQUIRE(os.str() == "STATE Ejected\n");
@@ -46,7 +46,7 @@ SCENARIO("NoAudio emits state, but no file or position", "[no-audio]") {
 		WHEN("the NoAudio is asked to emit a FILE") {
 			std::ostringstream os;
 			DummyResponseSink rs(os);
-			n.Emit(Response::Code::FILE, &rs);
+			n.Emit(Response::Code::FILE, &rs, 0);
 
 			THEN("nothing is emitted") {
 				REQUIRE(os.str().empty());
@@ -56,7 +56,7 @@ SCENARIO("NoAudio emits state, but no file or position", "[no-audio]") {
 		WHEN("the NoAudio is asked to emit a TIME") {
 			std::ostringstream os;
 			DummyResponseSink rs(os);
-			n.Emit(Response::Code::TIME, &rs);
+			n.Emit(Response::Code::TIME, &rs, 0);
 
 			THEN("nothing is emitted") {
 				REQUIRE(os.str().empty());


### PR DESCRIPTION
* Ignore `SIGPIPE`, to stop playd from crashing on POSIX-based systems if it tries to write to a dead connection.
* Everything that emits responses now does so to `IoCore`, but is given a handle to the specific connection wanting a response (`0` for broadcast).  This number is unique to the connection up to disconnection/reconnection: [there is a possibility that a connection could receive a dead connection's pending responses, and this might want to be fixed later][ABA].  This prevents references to connections (which could die at any minute) from being spilled out, and ensures the `IoCore` has direct responsibility over all writes.
* Command results (`OK`, `OHAI`, `WHAT`) are now sent unicast to the connection whence the command came.  This prevents spamming of unrelated connections.
* Merge `IoCore` and `ConnectionPool` to remove a level of indirection and simplify the code a bit.

Possible issues:
* The `#ifdef` on `SIGPIPE` will need tweaking on non-POSIX non-MSVC targets.  `SIGPIPE` is not a standard C-ism, and, where it doesn't exist, it should not be used.
* Aforementioned instance of the [ABA] problem.
* Currently, `0` is a magic constant for broadcasting.  I considered making a constant, then realised that most of the implementation of the connection pool depends on it being `0`, so a constant would either mean that implementation would be difficult to express in terms of the constant, or changes to the constant in isolation would manifest in weird errors in the implementation.

Further goals:
* Remove/rename `ResponseSink` to show that it exists solely to break the `IoCore`<->`Player` cyclic reference
* General cleanup

[ABA]: http://en.wikipedia.org/wiki/ABA_problem