### PR TITLE
Add 'dump' command.

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -366,7 +366,7 @@ void Connection::RunCommand(const std::vector<std::string> &cmd)
 	for (const auto &word : cmd) std::cerr << ' ' << '"' << word << '"';
 	std::cerr << std::endl;
 
-	CommandResult res = this->player.RunCommand(cmd);
+	CommandResult res = this->player.RunCommand(cmd, this->id);
 	res.Emit(this->parent, cmd, this->id);
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -50,11 +50,13 @@ bool Player::Update()
 	return this->is_running;
 }
 
-void Player::EmitAllAudioState(size_t id) const
+CommandResult Player::EmitAllAudioState(size_t id) const
 {
 	this->file->Emit(Response::Code::FILE, sink, id);
 	this->file->Emit(Response::Code::TIME, sink, id);
 	this->file->Emit(Response::Code::STATE, sink, id);
+
+	return CommandResult::Success();
 }
 
 void Player::WelcomeClient(size_t id) const
@@ -87,14 +89,14 @@ void Player::End()
 // Commands
 //
 
-CommandResult Player::RunCommand(const std::vector<std::string> &cmd)
+CommandResult Player::RunCommand(const std::vector<std::string> &cmd, size_t id)
 {
 	switch (cmd.size()) {
 		case 1:
-			return this->RunNullaryCommand(cmd[0]);
+			return this->RunNullaryCommand(cmd[0], id);
 		case 2:
 			if (!cmd[1].empty()) {
-				return this->RunUnaryCommand(cmd[0], cmd[1]);
+				return this->RunUnaryCommand(cmd[0], cmd[1], id);
 			}
 			return CommandResult::Invalid(MSG_CMD_INVALID);
 		default:
@@ -102,10 +104,11 @@ CommandResult Player::RunCommand(const std::vector<std::string> &cmd)
 	}
 }
 
-CommandResult Player::RunNullaryCommand(const std::string &word)
+CommandResult Player::RunNullaryCommand(const std::string &word, size_t id)
 {
 	if ("play" == word) return this->SetPlaying(true);
 	if ("stop" == word) return this->SetPlaying(false);
+	if ("dump" == word) return this->EmitAllAudioState(id);
 	if ("eject" == word) return this->Eject();
 	if ("quit" == word) return this->Quit();
 
@@ -113,7 +116,8 @@ CommandResult Player::RunNullaryCommand(const std::string &word)
 }
 
 CommandResult Player::RunUnaryCommand(const std::string &word,
-                                      const std::string &arg)
+                                      const std::string &arg,
+                                      size_t)
 {
 	if ("load" == word) return this->Load(arg);
 	if ("seek" == word) return this->Seek(arg);

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -45,9 +45,12 @@ public:
 	/**
 	 * Handles a command line.
 	 * @param cmd A reference to the list of words in the command.
+	 * @param id If present, the ID of the client requesting the
+	 *   command, and, thus, the target of any unicast responses
+	 *   this command generates.
 	 * @return Whether the command succeeded.
 	 */
-	CommandResult RunCommand(const std::vector<std::string> &words);
+	CommandResult RunCommand(const std::vector<std::string> &words, size_t id = 0);
 
 	/**
 	 * Sets the sink to which this Player shall send responses.
@@ -67,6 +70,7 @@ public:
 	/**
 	 * Sends welcome/current status information to a new client.
 	 * @param id The ID of the new client inside the IO system.
+	 * @see DumpState
 	 */
 	void WelcomeClient(size_t id) const;
 
@@ -86,20 +90,22 @@ private:
 	/**
 	 * Runs a nullary (0-argument) command.
 	 * @param word The command word.
+	 * @param id The ID of the client requesting the command.
 	 * @return True if the command was successfully found and executed;
 	 *   false otherwise.
 	 */
-	CommandResult RunNullaryCommand(const std::string &word);
+	CommandResult RunNullaryCommand(const std::string &word, size_t id);
 
 	/**
 	 * Runs a unary (1-argument) command.
 	 * @param word The command word.
 	 * @param arg The argument to the command.
+	 * @param id The ID of the client requesting the command.
 	 * @return True if the command was successfully found and executed;
 	 *   false otherwise.
 	 */
 	CommandResult RunUnaryCommand(const std::string &word,
-	                              const std::string &arg);
+	                              const std::string &arg, size_t id);
 
 	//
 	// Playback control
@@ -180,11 +186,10 @@ private:
 	 * Asks the current file to dump all of its state to the connection
 	 * with the given ID.
 	 * @param id The ID of the connection to receive the dump.
-	 * @note This is a pointer, not a reference, so as to allow nullptr
-	 *   (which means no sink is assigned).  When `optional` becomes
-	 *   standard, perhaps use that.
+	 * @return A successful CommandResult, to allow this function
+	 * to be used in the dump command.
 	 */
-	void EmitAllAudioState(size_t id) const;
+	CommandResult EmitAllAudioState(size_t id) const;
 };
 
 #endif // PLAYD_PLAYER_HPP


### PR DESCRIPTION
This currently-not-spec'd command, by popular demand, dumps all of the
initial responses, sans OHAI and FEATURES.  It only dumps to the sender,
not the whole connection pool.

Happy now?