### PR TITLE
Improve quit 

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -201,10 +201,8 @@ void IoCore::ExpandPool()
 	//
 	// Why -1?  Because slot 0 in the connection pool is reserved for
 	// broadcasts.
-
-	if (this->pool.size() == (SIZE_MAX - 1)) {
-		throw InternalError("too many simultaneous connections");
-	}
+	bool full = this->pool.size() == (SIZE_MAX - 1);
+	if (full) throw InternalError(MSG_TOO_MANY_CONNS);
 
 	this->pool.emplace_back(nullptr);
 	// This isn't an off-by-one error; slots index from 1.

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -81,6 +81,13 @@ public:
 	 */
 	void Remove(size_t id);
 
+	/**
+	 * Performs a player update cycle.
+	 * If the player is closing, IoCore will announce this fact to
+	 * all current connections, close them, and end the I/O loop.
+	 */
+	void UpdatePlayer();
+
 	void Respond(const Response &response, size_t id = 0) const override;
 
 private:
@@ -145,8 +152,10 @@ public:
 	/**
 	 * Emits a Response via this Connection.
 	 * @param response The response to send.
+	 * @param fatal If true, the Connection will close upon
+	 *   receiving the response.
 	 */
-	void Respond(const Response &response) const;
+	void Respond(const Response &response, bool fatal = false);
 
 	/**
 	 * Processes a data read on this connection.

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -119,6 +119,44 @@ private:
 
 	/// Shuts down the IoCore by terminating all IO loop tasks.
 	void Shutdown();
+
+	//
+	// Connection pool handling
+	//
+
+	/**
+	 * Acquires the next available connection ID.
+	 * This ID may have been assigned to a connection in the past, but is
+	 * guaranteed not to match any currently assigned IDs.
+	 * @return size_t A fresh ID for use.
+	 */
+	size_t NextConnectionID();
+
+	/**
+	 * Adds a new connection slot to the connection pool.
+	 * This is called by NextConnectionID when the number of currently
+	 * running connections is larger than the number of existing pool
+	 * slots, and will eventually fail (when the number of simultaneous
+	 * connections reaches absurd proportions).
+	 */
+	void ExpandPool();
+
+	//
+	// Response dispatch
+	//
+
+	/**
+	 * Sends the given response to all connections.
+	 * @param response The response to broadcast.
+	 */
+	void Broadcast(const Response &response) const;
+
+	/**
+	 * Sends the given response to the identified connection.
+	 * @param response The response to broadcast.
+	 * @param id The ID of the recipient connection.
+	 */
+	void Unicast(const Response &response, size_t id) const;
 };
 
 /**

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -116,6 +116,9 @@ private:
 
 	/// Sets up a periodic timer to run the playd update loop.
 	void DoUpdateTimer();
+
+	/// Shuts down the IoCore by terminating all IO loop tasks.
+	void Shutdown();
 };
 
 /**

--- a/src/messages.h
+++ b/src/messages.h
@@ -46,6 +46,9 @@ const std::string MSG_CMD_NEEDS_PLAYING = "Command requires a playing file";
  */
 const std::string MSG_CMD_NEEDS_STOPPED = "Command requires a stopped file";
 
+/// Message shown when a command is sent to a closing Player.
+const std::string MSG_CMD_PLAYER_CLOSING = "Server is closing";
+
 //
 // Decoder failures
 //

--- a/src/messages.h
+++ b/src/messages.h
@@ -90,4 +90,11 @@ const std::string MSG_SEEK_FAIL = "Seek failed";
 /// Message shown when a seek command has an invalid time value.
 const std::string MSG_SEEK_INVALID_VALUE = "Invalid time: try integer";
 
+//
+// IO failures
+//
+
+/// Message shown when too many simultaneous connections are launched.
+const std::string MSG_TOO_MANY_CONNS = "too many simultaneous connections";
+
 #endif // PLAYD_MESSAGES_H

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -91,6 +91,13 @@ void Player::End()
 
 CommandResult Player::RunCommand(const std::vector<std::string> &cmd, size_t id)
 {
+	if (!this->is_running) {
+		// Refuse any and all commands when not running.
+		// This is mainly to prevent the internal state from
+		// going weird, but seems logical anyway.
+		return CommandResult::Failure(MSG_CMD_PLAYER_CLOSING);
+	}
+
 	switch (cmd.size()) {
 		case 1:
 			return this->RunNullaryCommand(cmd[0], id);

--- a/src/tests/player.cpp
+++ b/src/tests/player.cpp
@@ -31,8 +31,14 @@ SCENARIO("Player accurately represents whether it is running", "[player]") {
 		}
 		WHEN("quit has been sent") {
 			auto res = p.RunCommand(std::vector<std::string>{"quit"});
+			THEN("The quit was a success") {
+				REQUIRE(res.IsSuccess());
+			}
 			THEN("Update returns false (the player is no longer running)") {
 				REQUIRE_FALSE(p.Update());
+			}
+			THEN("Any future quits fail") {
+				REQUIRE_FALSE(p.RunCommand(std::vector<std::string>{"quit"}).IsSuccess());
 			}
 		}
 	}


### PR DESCRIPTION
This PRQ ensures that:

* Sends of `quit` cause an acknowledgment (currently `STATE Quitting`) to be sent to each connection before it closes, to distinguish between a legitimate `quit` and more-abrupt server termination;
* The IO loop is now closed _implicitly_ (by closing the TCP server and update timer immediately, and then sending each connection a 'fatal' ack response that closes the connection upon successful delivery);
* Commands sent after a `quit` (but not necessarily after the acknowledgement, because of the way the ack is sent by the `IoCore`) are met with `FAIL`ure.

**Note**: This only presently works for actual sends of `quit` (the technically-correct way to end a playd).  If a ctrl-c is sent, then I don't think playd currently handles this specially at all, and thus the server will just die ungracefully.  Perhaps this can be fixed later.  **(End of note.)**

Possible changes:
* Change the response to something else (eg `BYE`) (would need a spec change)
* Send `STATE Quitting` from the `Player`, but have the 'I'm definitely going now' response come from `IoCore` and be `BYE` etc.
* Any suggestions to make this not a tangled mess of weird callback soup are appreciated.