### PR TITLE
Nitpicky cleanup

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -22,6 +22,15 @@
 #include "sample_formats.hpp"
 
 //
+// Audio
+//
+
+void Audio::Emit(Response::Code, const ResponseSink *, size_t)
+{
+	// By default, emit nothing.  This is an acceptable behaviour.
+}
+
+//
 // NoAudio
 //
 

--- a/src/audio/audio.hpp
+++ b/src/audio/audio.hpp
@@ -92,7 +92,7 @@ public:
 	 *   route the response.  May be 0 (the default), for all (broadcast).
 	 */
 	virtual void Emit(Response::Code code, const ResponseSink *sink,
-	                  size_t id = 0) = 0;
+	                  size_t id = 0);
 
 	/**
 	 * This Audio's current position.

--- a/src/audio/audio.hpp
+++ b/src/audio/audio.hpp
@@ -85,7 +85,7 @@ public:
 	/**
 	 * Emits the requested response.
 	 *
-	 * @param response The response to emit, if possible.
+	 * @param code The code of the response to emit, if possible.
 	 * @param sink The ResponseSink to which the response shall be sent.
 	 *   May be nullptr, in which case Emit should be a no-operation.
 	 * @param id The ID of the connection to which the ResponseSink should

--- a/src/audio/audio_sink.cpp
+++ b/src/audio/audio_sink.cpp
@@ -23,6 +23,19 @@
 #include "ringbuffer.hpp"
 #include "sample_formats.hpp"
 
+//
+// AudioSink
+//
+
+Audio::State AudioSink::State()
+{
+	return Audio::State::NONE;
+}
+
+//
+// SdlAudioSink
+//
+
 const size_t SdlAudioSink::RINGBUF_POWER = 16;
 
 /**

--- a/src/audio/audio_sink.hpp
+++ b/src/audio/audio_sink.hpp
@@ -52,7 +52,7 @@ public:
 	 * @return The Audio::State representing this AudioSink's state.
 	 * @see Audio::State
 	 */
-	virtual Audio::State State() = 0;
+	virtual Audio::State State();
 
 	/**
 	 * Gets the current played position in the song, in samples.

--- a/src/audio/audio_sink.hpp
+++ b/src/audio/audio_sink.hpp
@@ -139,12 +139,10 @@ public:
 	 * The callback proper.
 	 * This is executed in a separate thread by SDL once a stream is
 	 * playing with the callback registered to it.
-	 * @param outputBuffer The output buffer to which our samples should
-	 *   be written.
-	 * @param numFrames The number of samples PortAudio wants to read from
-	 *   @a outputBuffer.
+	 * @param out The output buffer to which our samples should be written.
+	 * @param nbytes The number of bytes SDL wants to read from @a out.
 	 */
-	void Callback(std::uint8_t *inputBuffer, int numFrames);
+	void Callback(std::uint8_t *out, int nbytes);
 
 	/**
 	 * Converts a sample format identifier from playd to SDL.

--- a/src/audio/audio_source.hpp
+++ b/src/audio/audio_source.hpp
@@ -112,20 +112,20 @@ public:
 	 * count as a factor.
 	 * @return The number of bytes per sample.
 	 */
-	size_t BytesPerSample() const;
+	virtual size_t BytesPerSample() const;
 
 	/**
 	 * Gets the file-path of this audio source's audio file.
 	 * @return The audio file's path.
 	 */
-	const std::string &Path() const;
+	virtual const std::string &Path() const;
 
 	/**
 	 * Converts a position in microseconds to an elapsed sample count.
 	 * @param micros The song position, in microseconds.
 	 * @return The corresponding number of elapsed samples.
 	 */
-	std::uint64_t SamplesFromMicros(std::uint64_t micros) const;
+	virtual std::uint64_t SamplesFromMicros(std::uint64_t micros) const;
 
 	/**
 	 * Converts an elapsed sample count to a position in microseconds.

--- a/src/audio/audio_source.hpp
+++ b/src/audio/audio_source.hpp
@@ -97,7 +97,7 @@ public:
 	/**
 	 * Seeks to the given position, in samples.
 	 * For convenience, the new position (in terms of samples) is returned.
-	 * @param in_samples  The new position in the file, in samples.
+	 * @param position The requested new position in the file, in samples.
 	 * @return The new position in the file, in samples.
 	 */
 	virtual std::uint64_t Seek(std::uint64_t position) = 0;
@@ -122,7 +122,7 @@ public:
 
 	/**
 	 * Converts a position in microseconds to an elapsed sample count.
-	 * @param position The song position, in microseconds.
+	 * @param micros The song position, in microseconds.
 	 * @return The corresponding number of elapsed samples.
 	 */
 	std::uint64_t SamplesFromMicros(std::uint64_t micros) const;

--- a/src/audio/audio_system.cpp
+++ b/src/audio/audio_system.cpp
@@ -69,7 +69,7 @@ void AudioSystem::SetSink(AudioSystem::SinkBuilder sink)
 }
 
 void AudioSystem::AddSource(const std::string &ext,
-                                AudioSystem::SourceBuilder source)
+                            AudioSystem::SourceBuilder source)
 {
 	this->sources.emplace(ext, source);
 }

--- a/src/audio/audio_system.cpp
+++ b/src/audio/audio_system.cpp
@@ -3,7 +3,7 @@
 
 /**
  * @file
- * Implementation of the PipeAudioSystem class.
+ * Implementation of the AudioSystem class.
  * @see audio/audio_system.hpp
  */
 
@@ -27,20 +27,20 @@
 #include "sources/mp3.hpp"
 #include "sources/sndfile.hpp"
 
-PipeAudioSystem::PipeAudioSystem(int device_id)
-    : device_id(device_id),
-      sink([](const AudioSource &, int) -> std::unique_ptr<AudioSink> {
+AudioSystem::AudioSystem(int device_id)
+    : sink([](const AudioSource &, int) -> std::unique_ptr<AudioSink> {
 	      throw InternalError("No audio sink!");
-      })
+      }),
+      device_id(device_id)
 {
 }
 
-std::unique_ptr<Audio> PipeAudioSystem::Null() const
+std::unique_ptr<Audio> AudioSystem::Null() const
 {
 	return std::unique_ptr<Audio>(new NoAudio());
 }
 
-std::unique_ptr<Audio> PipeAudioSystem::Load(const std::string &path) const
+std::unique_ptr<Audio> AudioSystem::Load(const std::string &path) const
 {
 	std::unique_ptr<AudioSource> source = this->LoadSource(path);
 	assert(source != nullptr);
@@ -50,7 +50,7 @@ std::unique_ptr<Audio> PipeAudioSystem::Load(const std::string &path) const
 	        new PipeAudio(std::move(source), std::move(sink)));
 }
 
-std::unique_ptr<AudioSource> PipeAudioSystem::LoadSource(const std::string &path) const
+std::unique_ptr<AudioSource> AudioSystem::LoadSource(const std::string &path) const
 {
 	size_t extpoint = path.find_last_of('.');
 	std::string ext = path.substr(extpoint + 1);
@@ -63,13 +63,13 @@ std::unique_ptr<AudioSource> PipeAudioSystem::LoadSource(const std::string &path
 	return (ibuilder->second)(path);
 }
 
-void PipeAudioSystem::SetSink(PipeAudioSystem::SinkBuilder sink)
+void AudioSystem::SetSink(AudioSystem::SinkBuilder sink)
 {
 	this->sink = sink;
 }
 
-void PipeAudioSystem::AddSource(const std::string &ext,
-                                PipeAudioSystem::SourceBuilder source)
+void AudioSystem::AddSource(const std::string &ext,
+                                AudioSystem::SourceBuilder source)
 {
 	this->sources.emplace(ext, source);
 }

--- a/src/audio/audio_system.hpp
+++ b/src/audio/audio_system.hpp
@@ -89,7 +89,7 @@ public:
 
 	/**
 	 * Assign an AudioSource for a file extension.
-	 * @param exts The file extension to associate with this source.
+	 * @param ext The file extension to associate with this source.
 	 * @param source The function to use when building source.
 	 * @note If two AddSource invocations name the first file extension,
 	 *   the first is used for said extension.

--- a/src/audio/audio_system.hpp
+++ b/src/audio/audio_system.hpp
@@ -23,44 +23,15 @@
  *
  * The AudioSystem is responsible for creating Audio instances,
  * enumerating and resolving device IDs, and initialising and terminating the
- * audio libraries.
+ * audio libraries.  It creates Audio by chaining together audio _sources_,
+ * selected by file extension, and an audio _sink_.
  *
- * This is an abstract class, implemented primarily by PipeAudioSystem.
- *
- * @see PipeAudioSystem
- * @see Audio
- */
-class AudioSystem
-{
-public:
-	/// Virtual, empty destructor for AudioSystem.
-	virtual ~AudioSystem() = default;
-
-	/**
-	 * Creates an Audio for a lack of audio.
-	 * @return A unique pointer to a dummy Audio.
-	 */
-	virtual std::unique_ptr<Audio> Null() const = 0;
-
-	/**
-	 * Loads a file, creating an Audio for it.
-	 * @param path The path to a file.
-	 * @return A unique pointer to the Audio for that file.
-	 */
-	virtual std::unique_ptr<Audio> Load(const std::string &path) const = 0;
-};
-
-/**
- * A modular AudioSystem that constructs PipeAudio.
- *
- * PipeAudioSystem creates Audio by chaining together audio _sources_, selected
- * by file extension, and an audio _sink_.
- *
+ * @see NoAudio
  * @see PipeAudio
  * @see AudioSink
  * @see AudioSource
  */
-class PipeAudioSystem : public AudioSystem
+class AudioSystem
 {
 public:
 	/// Type for functions that construct sinks.
@@ -72,14 +43,23 @@ public:
 	        std::function<std::unique_ptr<AudioSource>(const std::string &)>;
 
 	/**
-	 * Constructs a PipeAudioSystem.
+	 * Constructs a AudioSystem.
 	 * @param device_id The device ID to which sinks shall output.
 	 */
-	PipeAudioSystem(int device_id);
+	AudioSystem(int device_id);
 
-	// AudioSystem implementation
-	std::unique_ptr<Audio> Null() const override;
-	std::unique_ptr<Audio> Load(const std::string &path) const override;
+	/**
+	 * Creates an Audio for a lack of audio.
+	 * @return A unique pointer to a dummy Audio.
+	 */
+	std::unique_ptr<Audio> Null() const;
+
+	/**
+	 * Loads a file, creating an Audio for it.
+	 * @param path The path to a file.
+	 * @return A unique pointer to the Audio for that file.
+	 */
+	std::unique_ptr<Audio> Load(const std::string &path) const;
 
 	/**
 	 * Sets the sink to use for outputting sound.

--- a/src/audio/audio_system.hpp
+++ b/src/audio/audio_system.hpp
@@ -97,14 +97,14 @@ public:
 	void AddSource(const std::string &ext, SourceBuilder source);
 
 private:
-	/// The device ID for the sink.
-	int device_id;
-
 	/// The current sink builder.
 	SinkBuilder sink;
 
 	/// Map from file extensions to source builders.
 	std::map<std::string, SourceBuilder> sources;
+
+	/// The device ID for the sink.
+	int device_id;
 
 	/**
 	 * Loads a file, creating an AudioSource.

--- a/src/cmd_result.cpp
+++ b/src/cmd_result.cpp
@@ -29,7 +29,7 @@ CommandResult CommandResult::Failure(const std::string &msg)
 }
 
 CommandResult::CommandResult(Response::Code type, const std::string &msg)
-    : type(type), msg(msg)
+    : msg(msg), type(type)
 {
 }
 

--- a/src/cmd_result.hpp
+++ b/src/cmd_result.hpp
@@ -77,8 +77,8 @@ public:
 	          size_t id = 0) const;
 
 private:
-	Response::Code type; ///< The command result's response code.
 	std::string msg;     ///< The command result's message.
+	Response::Code type; ///< The command result's response code.
 };
 
 #endif // PLAYD_CMD_RESULT

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -155,8 +155,7 @@ void IoCore::Accept(uv_stream_t *server)
 	}
 
 	auto id = this->NextConnectionID();
-	auto conn = std::make_shared<Connection>(*this, client, this->player,
-	                                         id);
+	auto conn = std::make_shared<Connection>(*this, client, this->player, id);
 	client->data = static_cast<void *>(conn.get());
 	this->pool[id - 1] = std::move(conn);
 
@@ -216,7 +215,6 @@ void IoCore::Remove(size_t slot)
 	}
 
 	assert(!this->pool.at(slot - 1));
-
 }
 
 void IoCore::UpdatePlayer()
@@ -240,8 +238,10 @@ void IoCore::Shutdown()
 
 	// Finally, kill off all of the connections with 'fatal' responses.
 	for (const auto conn : this->pool) {
-		if (conn) conn->Respond(Response(Response::Code::STATE)
-		                        .AddArg("Quitting"), true);
+		if (conn)
+			conn->Respond(Response(Response::Code::STATE)
+			                      .AddArg("Quitting"),
+			              true);
 	}
 }
 
@@ -271,8 +271,8 @@ void IoCore::Unicast(const Response &response, size_t id) const
 {
 	assert(0 < id && id <= this->pool.size());
 
-	Debug() << "unicast @" << std::to_string(id) << ":"
-		<< response.Pack() << std::endl;
+	Debug() << "unicast @" << std::to_string(id) << ":" << response.Pack()
+	        << std::endl;
 
 	auto conn = this->pool.at(id - 1);
 	if (conn) conn->Respond(response);

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -237,7 +237,7 @@ void IoCore::Shutdown()
 	uv_close(reinterpret_cast<uv_handle_t *>(&this->server), nullptr);
 
 	// Finally, kill off all of the connections with 'fatal' responses.
-	for (const auto conn : this->pool) this->TryShutdown(conn);
+	for (const auto conn : this->pool) IoCore::TryShutdown(conn);
 }
 
 /* static */ void IoCore::TryShutdown(const std::shared_ptr<Connection> conn)

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -146,6 +146,28 @@ private:
 	//
 
 	/**
+	 * Sends a normal response to the given connection.
+	 * The difference between this and conn->Respond is that TryRespond
+	 * checks the shared pointer for emptiness.
+	 * @param conn The connection to receive the response.  May be empty,
+	 *   in which case no response is sent.
+	 * @see TryShutdown
+	 */
+	static void TryRespond(const std::shared_ptr<Connection> conn,
+	                       const Response &response);
+
+	/**
+	 * Sends a 'this server is shutting down' response to the given
+	 * connection.
+	 * The difference between this and conn->Respond is that TryShutdown
+	 * checks the shared pointer for emptiness.
+	 * @param conn The connection to receive the response.  May be empty,
+	 *   in which case no response is sent.
+	 * @see TryRespond
+	 */
+	static void TryShutdown(const std::shared_ptr<Connection> conn);
+
+	/**
 	 * Sends the given response to all connections.
 	 * @param response The response to broadcast.
 	 */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,7 +76,7 @@ int GetDeviceID(const std::vector<std::string> &args)
  * Sets up the audio system with the desired sources and sinks.
  * @param audio The audio system to configure.
  */
-void SetupAudioSystem(PipeAudioSystem &audio)
+void SetupAudioSystem(AudioSystem &audio)
 {
 	audio.SetSink(&SdlAudioSink::Build);
 
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
 	if (device_id < 0) ExitWithUsage(args.at(0));
 
 	// Set up all of the components of playd in one fell swoop.
-	PipeAudioSystem audio(device_id);
+	AudioSystem audio(device_id);
 	SetupAudioSystem(audio);
 	Player player(audio);
 	IoCore io(player);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -98,17 +98,9 @@ CommandResult Player::RunCommand(const std::vector<std::string> &cmd, size_t id)
 		return CommandResult::Failure(MSG_CMD_PLAYER_CLOSING);
 	}
 
-	switch (cmd.size()) {
-		case 1:
-			return this->RunNullaryCommand(cmd[0], id);
-		case 2:
-			if (!cmd[1].empty()) {
-				return this->RunUnaryCommand(cmd[0], cmd[1], id);
-			}
-			return CommandResult::Invalid(MSG_CMD_INVALID);
-		default:
-			return CommandResult::Invalid(MSG_CMD_INVALID);
-	}
+	if (cmd.size() == 1) return this->RunNullaryCommand(cmd[0], id);
+	if (cmd.size() == 2) return this->RunUnaryCommand(cmd[0], cmd[1], id);
+	return CommandResult::Invalid(MSG_CMD_INVALID);
 }
 
 CommandResult Player::RunNullaryCommand(const std::string &word, size_t id)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -123,8 +123,7 @@ CommandResult Player::RunNullaryCommand(const std::string &word, size_t id)
 }
 
 CommandResult Player::RunUnaryCommand(const std::string &word,
-                                      const std::string &arg,
-                                      size_t)
+                                      const std::string &arg, size_t)
 {
 	if ("load" == word) return this->Load(arg);
 	if ("seek" == word) return this->Seek(arg);

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -44,7 +44,7 @@ public:
 
 	/**
 	 * Handles a command line.
-	 * @param cmd A reference to the list of words in the command.
+	 * @param words A reference to the list of words in the command.
 	 * @param id If present, the ID of the client requesting the
 	 *   command, and, thus, the target of any unicast responses
 	 *   this command generates.

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -50,7 +50,8 @@ public:
 	 *   this command generates.
 	 * @return Whether the command succeeded.
 	 */
-	CommandResult RunCommand(const std::vector<std::string> &words, size_t id = 0);
+	CommandResult RunCommand(const std::vector<std::string> &words,
+	                         size_t id = 0);
 
 	/**
 	 * Sets the sink to which this Player shall send responses.

--- a/src/response.cpp
+++ b/src/response.cpp
@@ -48,7 +48,7 @@ std::string Response::Pack() const
 	bool escaping = false;
 	std::string escaped;
 
-	for (unsigned char c : arg) {
+	for (char c : arg) {
 		// These are the characters (including all whitespace, via
 		// isspace())  whose presence means we need to single-quote
 		// escape the argument.

--- a/src/response.hpp
+++ b/src/response.hpp
@@ -85,6 +85,9 @@ private:
 class ResponseSink
 {
 public:
+	/// Empty virtual destructor for ResponseSink.
+	virtual ~ResponseSink() = default;
+
 	/**
 	 * Outputs a response.
 	 * @param response The Response to output.

--- a/src/tests/dummy_audio_source.cpp
+++ b/src/tests/dummy_audio_source.cpp
@@ -45,7 +45,7 @@ std::uint64_t DummyAudioSource::Seek(std::uint64_t position)
 	return this->position;
 }
 
-std::string DummyAudioSource::Path() const
+const std::string &DummyAudioSource::Path() const
 {
 	return this->path;
 }

--- a/src/tests/dummy_audio_source.hpp
+++ b/src/tests/dummy_audio_source.hpp
@@ -37,7 +37,7 @@ public:
 	std::uint64_t Seek(std::uint64_t position) override;
 
 	/// @return The path of the DummyAudioSource.
-	std::string Path() const;
+	const std::string &Path() const;
 
 	/// The position of the AudioSource, in samples.
 	std::uint64_t position;

--- a/src/tests/pipe_audio_system.cpp
+++ b/src/tests/pipe_audio_system.cpp
@@ -3,7 +3,7 @@
 
 /**
  * @file
- * Tests for PipeAudioSystem.
+ * Tests for AudioSystem.
  */
 
 #include "catch.hpp"
@@ -14,9 +14,9 @@
 #include "dummy_audio_sink.hpp"
 #include "dummy_audio_source.hpp"
 
-SCENARIO("PipeAudioSystem can provide null implementations of Audio", "[pipe-audio-system][no-audio]") {
-	GIVEN("a fresh PipeAudioSystem") {
-		PipeAudioSystem sys(0);
+SCENARIO("AudioSystem can provide null implementations of Audio", "[pipe-audio-system][no-audio]") {
+	GIVEN("a fresh AudioSystem") {
+		AudioSystem sys(0);
 
 		WHEN("Null() is invoked") {
 			std::unique_ptr<Audio> au = sys.Null();
@@ -28,9 +28,9 @@ SCENARIO("PipeAudioSystem can provide null implementations of Audio", "[pipe-aud
 	}
 }
 
-SCENARIO("PipeAudioSystem cannot create Audio without a registered Sink", "[pipe-audio-system]") {
-	GIVEN("a PipeAudioSystem with dummy source loaded") {
-		PipeAudioSystem sys(0);
+SCENARIO("AudioSystem cannot create Audio without a registered Sink", "[pipe-audio-system]") {
+	GIVEN("a AudioSystem with dummy source loaded") {
+		AudioSystem sys(0);
 		sys.AddSource("bar", &DummyAudioSource::Build);
 
 		WHEN("Load() is invoked") {
@@ -41,10 +41,10 @@ SCENARIO("PipeAudioSystem cannot create Audio without a registered Sink", "[pipe
 	}
 }
 
-SCENARIO("PipeAudio can be constructed from a PipeAudioSystem", "[pipe-audio][pipe-audio-system]") {
-	GIVEN("a fresh PipeAudioSystem") {
-		PipeAudioSystem sys(0);
-		WHEN("the PipeAudioSystem is assigned a dummy AudioSink and AudioSource") {
+SCENARIO("PipeAudio can be constructed from a AudioSystem", "[pipe-audio][pipe-audio-system]") {
+	GIVEN("a fresh AudioSystem") {
+		AudioSystem sys(0);
+		WHEN("the AudioSystem is assigned a dummy AudioSink and AudioSource") {
 			sys.SetSink(&DummyAudioSink::Build);
 			sys.AddSource("bar", &DummyAudioSource::Build);
 
@@ -57,10 +57,10 @@ SCENARIO("PipeAudio can be constructed from a PipeAudioSystem", "[pipe-audio][pi
 	}
 }
 
-SCENARIO("PipeAudioSystems fail to load audio with an unknown format", "[pipe-audio-system]") {
-	GIVEN("a fresh PipeAudioSystem") {
-		PipeAudioSystem sys(0);
-		WHEN("the PipeAudioSystem is assigned a dummy AudioSink") {
+SCENARIO("AudioSystems fail to load audio with an unknown format", "[pipe-audio-system]") {
+	GIVEN("a fresh AudioSystem") {
+		AudioSystem sys(0);
+		WHEN("the AudioSystem is assigned a dummy AudioSink") {
 			sys.SetSink(&DummyAudioSink::Build);
 
 			AND_WHEN("no AudioSource is set") {

--- a/src/tests/player.cpp
+++ b/src/tests/player.cpp
@@ -17,8 +17,8 @@
 #include "dummy_response_sink.hpp"
 
 SCENARIO("Player accurately represents whether it is running", "[player]") {
-	GIVEN("a fresh Player using PipeAudioSystem, DummyAudioSink and DummyAudioSource") {
-		PipeAudioSystem ds(0);
+	GIVEN("a fresh Player using AudioSystem, DummyAudioSink and DummyAudioSource") {
+		AudioSystem ds(0);
 		Player p(ds);
 
 		ds.SetSink(&DummyAudioSink::Build);
@@ -44,9 +44,9 @@ SCENARIO("Player accurately represents whether it is running", "[player]") {
 	}
 }
 
-SCENARIO("Player interacts correctly with a PipeAudioSystem", "[player][dummy-audio-system]") {
-	GIVEN("a fresh Player using PipeAudioSystem, DummyAudioSink and DummyAudioSource") {
-		PipeAudioSystem ds(0);
+SCENARIO("Player interacts correctly with a AudioSystem", "[player][dummy-audio-system]") {
+	GIVEN("a fresh Player using AudioSystem, DummyAudioSink and DummyAudioSource") {
+		AudioSystem ds(0);
 		Player p(ds);
 
 		ds.SetSink(&DummyAudioSink::Build);

--- a/src/tokeniser.cpp
+++ b/src/tokeniser.cpp
@@ -26,7 +26,7 @@ std::vector<std::vector<std::string>> Tokeniser::Feed(const std::string &raw)
 	// The list of ready lines should be cleared by any previous Feed.
 	assert(this->ready_lines.empty());
 
-	for (unsigned char c : raw) {
+	for (char c : raw) {
 		if (this->escape_next) {
 			this->Push(c);
 			continue;
@@ -93,7 +93,7 @@ std::vector<std::vector<std::string>> Tokeniser::Feed(const std::string &raw)
 	return lines;
 }
 
-void Tokeniser::Push(unsigned char c)
+void Tokeniser::Push(const char c)
 {
 	assert(this->escape_next ||
 	       !(this->quote_type == QuoteType::NONE && isspace(c)));

--- a/src/tokeniser.hpp
+++ b/src/tokeniser.hpp
@@ -74,7 +74,7 @@ private:
 	 * This also clears the escape_next flag.
 	 * @param c The character to push onto the current word.
 	 */
-	void Push(unsigned char c);
+	void Push(char c);
 };
 
 #endif // PLAYD_TOKENISER_HPP

--- a/src/tokeniser.hpp
+++ b/src/tokeniser.hpp
@@ -45,23 +45,23 @@ private:
 		DOUBLE  ///< In double quotes ("").
 	};
 
+	/// The current vector of completed, tokenised lines.
+	/// This is cleared at the end of every Tokeniser::Feed.
+	std::vector<std::vector<std::string>> ready_lines;
+
+	/// The current vector of completed, tokenised words.
+	std::vector<std::string> words;
+
+	/// The current, incomplete word to which new characters should be
+	/// added.
+	std::string current_word;
+
 	/// Whether the next character is to be interpreted as an escape code.
 	/// This usually gets set to true when a backslash is detected.
 	bool escape_next;
 
 	/// The type of quotation currently being used in this Tokeniser.
 	QuoteType quote_type;
-
-	/// The current vector of completed, tokenised words.
-	std::vector<std::string> words;
-
-	/// The current vector of completed, tokenised lines.
-	/// This is cleared at the end of every Tokeniser::Feed.
-	std::vector<std::vector<std::string>> ready_lines;
-
-	/// The current, incomplete word to which new characters should be
-	/// added.
-	std::string current_word;
 
 	/// Finishes the current word and sends the line to the CommandHandler.
 	void Emit();


### PR DESCRIPTION
Most of this is attempts to clean up some really, really pedantic warnings (`-Weverything`), but there are also some less controversial changes (merging `PipeAudioSystem` back into `AudioSystem` because there are no other `AudioSystem` implementations needed, and running `clang-format`).

Make of this what you will.