### PR TITLE
More spec-compliant tokeniser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,3 @@ script:
 # coveralls doesn't like gcc (segfaults)
 after_success:
   - if [ "$CXX" == "clang++-3.5" ]; then coveralls -b . --exclude src/tests --exclude src/contrib --gcov="`which llvm-cov-3.5`"; fi
-
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#ury"
-    template:
-      - "%{repository_name} %{branch} %{result} | %{build_url} | %{commit} by %{author}: %{commit_message}"
-    on_success: change
-    on_failure: change
-    use_notice: true
-    skip_join: true

--- a/src/tests/tokeniser.cpp
+++ b/src/tests/tokeniser.cpp
@@ -415,9 +415,9 @@ SCENARIO("Tokeniser is compliant with the BAPS3 spec", "[tokeniser][spec]") {
 		//	}
 		//}
 		WHEN("the Tokeniser is fed X1") {
-			auto lines = t.Feed("enqueue file \"C:\\\\Users\\\\Test\\\\Artist - Title.mp3\" 1\"\n");
+			auto lines = t.Feed("enqueue file \"C:\\\\Users\\\\Test\\\\Artist - Title.mp3\" 1\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 0);
+				REQUIRE(lines.size() == 1);
 				REQUIRE(lines[0].size() == 4);
 				REQUIRE(lines[0][0] == "enqueue");
 				REQUIRE(lines[0][1] == "file");

--- a/src/tests/tokeniser.cpp
+++ b/src/tests/tokeniser.cpp
@@ -210,7 +210,7 @@ SCENARIO("Tokenisers can backslash-escape bytes", "[tokeniser]") {
 	}
 }
 
-// See http://universityradioyork.github.io/baps3-spec/comms/internal/protocol.html
+// See http://universityradioyork.github.io/baps3-spec/tests/internal.html
 SCENARIO("Tokeniser is compliant with the BAPS3 spec", "[tokeniser][spec]") {
 	GIVEN("A fresh Tokeniser") {
 		Tokeniser t;

--- a/src/tests/tokeniser.cpp
+++ b/src/tests/tokeniser.cpp
@@ -404,14 +404,16 @@ SCENARIO("Tokeniser is compliant with the BAPS3 spec", "[tokeniser][spec]") {
 				REQUIRE(lines[0][1] == "武");
 			}
 		}
-		WHEN("the Tokeniser is fed U2") {
-			auto lines = t.Feed("f\xfcr\n");
-			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 1);
-				REQUIRE(lines[0][0] == "f\xef\xbf\xbdr");
-			}
-		}
+		// We don't implement UTF-8 replacement.
+		// Frankly, this should probably be removed from the spec tests.
+		//WHEN("the Tokeniser is fed U2") {
+		//	auto lines = t.Feed("f\xfcr\n");
+		//	THEN ("the Tokeniser returns the specified result") {
+		//		REQUIRE(lines.size() == 1);
+		//		REQUIRE(lines[0].size() == 1);
+		//		REQUIRE(lines[0][0] == "f\xef\xbf\xbdr");
+		//	}
+		//}
 		WHEN("the Tokeniser is fed X1") {
 			auto lines = t.Feed("enqueue file \"C:\\\\Users\\\\Test\\\\Artist - Title.mp3\" 1\"\n");
 			THEN ("the Tokeniser returns the specified result") {

--- a/src/tests/tokeniser.cpp
+++ b/src/tests/tokeniser.cpp
@@ -217,202 +217,209 @@ SCENARIO("Tokeniser is compliant with the BAPS3 spec", "[tokeniser][spec]") {
 		WHEN("the Tokeniser is fed E1") {
 			auto lines = t.Feed("");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 0);
+				std::vector<std::vector<std::string>> want = {};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed E2") {
 			auto lines = t.Feed("\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 0);
+				std::vector<std::vector<std::string>> want = {
+					{}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed E3") {
 			auto lines = t.Feed("''\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 1);
-				REQUIRE(lines[0][0] == "");
+				std::vector<std::vector<std::string>> want = {
+					{""}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed E4") {
 			auto lines = t.Feed("\"\"\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 1);
-				REQUIRE(lines[0][0] == "");
+				std::vector<std::vector<std::string>> want = {
+					{""}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed W1") {
 			auto lines = t.Feed("foo bar baz\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 3);
-				REQUIRE(lines[0][0] == "foo");
-				REQUIRE(lines[0][1] == "bar");
-				REQUIRE(lines[0][2] == "baz");
+				std::vector<std::vector<std::string>> want = {
+					{"foo", "bar", "baz"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed W2") {
 			auto lines = t.Feed("foo\tbar\tbaz\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 3);
-				REQUIRE(lines[0][0] == "foo");
-				REQUIRE(lines[0][1] == "bar");
-				REQUIRE(lines[0][2] == "baz");
+				std::vector<std::vector<std::string>> want = {
+					{"foo", "bar", "baz"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed W3") {
 			auto lines = t.Feed("foo\rbar\rbaz\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 3);
-				REQUIRE(lines[0][0] == "foo");
-				REQUIRE(lines[0][1] == "bar");
-				REQUIRE(lines[0][2] == "baz");
+				std::vector<std::vector<std::string>> want = {
+					{"foo", "bar", "baz"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed W4") {
 			auto lines = t.Feed("silly windows\r\n");
-			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 2);
-				REQUIRE(lines[0][0] == "silly");
-				REQUIRE(lines[0][1] == "windows");
+			THEN("the Tokeniser returns the specified result") {
+				std::vector<std::vector<std::string>> want = {
+					{"silly", "windows"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed W5") {
 			auto lines = t.Feed("    abc def\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 2);
-				REQUIRE(lines[0][0] == "abc");
-				REQUIRE(lines[0][1] == "def");
+				std::vector<std::vector<std::string>> want = {
+					{"abc", "def"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed W6") {
 			auto lines = t.Feed("ghi jkl    \n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 2);
-				REQUIRE(lines[0][0] == "ghi");
-				REQUIRE(lines[0][1] == "jkl");
+				std::vector<std::vector<std::string>> want = {
+					{"ghi", "jkl"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed W7") {
 			auto lines = t.Feed("    mno pqr    \n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 2);
-				REQUIRE(lines[0][0] == "mno");
-				REQUIRE(lines[0][1] == "pqr");
+				std::vector<std::vector<std::string>> want = {
+					{"mno", "pqr"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed Q1") {
 			auto lines = t.Feed("abc\\\ndef\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 1);
-				REQUIRE(lines[0][0] == "abc\ndef");
+				std::vector<std::vector<std::string>> want = {
+					{"abc\ndef"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed Q2") {
 			auto lines = t.Feed("\"abc\ndef\"\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 1);
-				REQUIRE(lines[0][0] == "abc\ndef");
+				std::vector<std::vector<std::string>> want = {
+					{"abc\ndef"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed Q3") {
 			auto lines = t.Feed("\"abc\\\ndef\"\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 1);
-				REQUIRE(lines[0][0] == "abc\ndef");
+				std::vector<std::vector<std::string>> want = {
+					{"abc\ndef"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed Q4") {
 			auto lines = t.Feed("'abc\ndef'\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 1);
-				REQUIRE(lines[0][0] == "abc\ndef");
+				std::vector<std::vector<std::string>> want = {
+					{"abc\ndef"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed Q5") {
 			auto lines = t.Feed("'abc\\\ndef'\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 1);
-				REQUIRE(lines[0][0] == "abc\\\ndef");
+				std::vector<std::vector<std::string>> want = {
+					{"abc\\\ndef"}
+				};
+
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed Q6") {
 			auto lines = t.Feed("Scare\\\" quotes\\\"\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 2);
-				REQUIRE(lines[0][0] == "Scare\"");
-				REQUIRE(lines[0][1] == "quotes\"");
+				std::vector<std::vector<std::string>> want = {
+					{"Scare\"", "quotes\""}
+				};
+
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed Q7") {
 			auto lines = t.Feed("I\\'m free\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 2);
-				REQUIRE(lines[0][0] == "I'm");
-				REQUIRE(lines[0][1] == "free");
+				std::vector<std::vector<std::string>> want = {
+					{"I'm", "free"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed Q8") {
 			auto lines = t.Feed("'hello, I'\\''m an escaped single quote'\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 1);
-				REQUIRE(lines[0][0] == "hello, I'm an escaped single quote");
+				std::vector<std::vector<std::string>> want = {
+					{"hello, I'm an escaped single quote"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed Q9") {
 			auto lines = t.Feed("\"hello, this is an \\\" escaped double quote\"\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 1);
-				REQUIRE(lines[0][0] == "hello, this is an \" escaped double quote");
+				std::vector<std::vector<std::string>> want = {
+					{"hello, this is an \" escaped double quote"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed M1") {
 			auto lines = t.Feed("first line\nsecond line\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 2);
-				REQUIRE(lines[0].size() == 2);
-				REQUIRE(lines[0][0] == "first");
-				REQUIRE(lines[0][1] == "line");
-				REQUIRE(lines[1].size() == 2);
-				REQUIRE(lines[1][0] == "second");
-				REQUIRE(lines[1][1] == "line");
+				std::vector<std::vector<std::string>> want = {
+					{"first", "line"},
+					{"second", "line"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed U1") {
 			auto lines = t.Feed("北野 武\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 2);
-				REQUIRE(lines[0][0] == "北野");
-				REQUIRE(lines[0][1] == "武");
+				std::vector<std::vector<std::string>> want = {
+					{"北野", "武"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 		WHEN("the Tokeniser is fed X1") {
 			auto lines = t.Feed("enqueue file \"C:\\\\Users\\\\Test\\\\Artist - Title.mp3\" 1\n");
 			THEN ("the Tokeniser returns the specified result") {
-				REQUIRE(lines.size() == 1);
-				REQUIRE(lines[0].size() == 4);
-				REQUIRE(lines[0][0] == "enqueue");
-				REQUIRE(lines[0][1] == "file");
-				REQUIRE(lines[0][2] == "C:\\Users\\Test\\Artist - Title.mp3");
-				REQUIRE(lines[0][3] == "1");
+				std::vector<std::vector<std::string>> want = {
+					{"enqueue", "file", "C:\\Users\\Test\\Artist - Title.mp3", "1"}
+				};
+				REQUIRE(lines == want);
 			}
 		}
 	}

--- a/src/tests/tokeniser.cpp
+++ b/src/tests/tokeniser.cpp
@@ -209,3 +209,219 @@ SCENARIO("Tokenisers can backslash-escape bytes", "[tokeniser]") {
 		}
 	}
 }
+
+// See http://universityradioyork.github.io/baps3-spec/comms/internal/protocol.html
+SCENARIO("Tokeniser is compliant with the BAPS3 spec", "[tokeniser][spec]") {
+	GIVEN("A fresh Tokeniser") {
+		Tokeniser t;
+		WHEN("the Tokeniser is fed E1") {
+			auto lines = t.Feed("");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 0);
+			}
+		}
+		WHEN("the Tokeniser is fed E2") {
+			auto lines = t.Feed("\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 0);
+			}
+		}
+		WHEN("the Tokeniser is fed E3") {
+			auto lines = t.Feed("''\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 1);
+				REQUIRE(lines[0][0] == "");
+			}
+		}
+		WHEN("the Tokeniser is fed E4") {
+			auto lines = t.Feed("\"\"\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 1);
+				REQUIRE(lines[0][0] == "");
+			}
+		}
+		WHEN("the Tokeniser is fed W1") {
+			auto lines = t.Feed("foo bar baz\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 3);
+				REQUIRE(lines[0][0] == "foo");
+				REQUIRE(lines[0][1] == "bar");
+				REQUIRE(lines[0][2] == "baz");
+			}
+		}
+		WHEN("the Tokeniser is fed W2") {
+			auto lines = t.Feed("foo\tbar\tbaz\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 3);
+				REQUIRE(lines[0][0] == "foo");
+				REQUIRE(lines[0][1] == "bar");
+				REQUIRE(lines[0][2] == "baz");
+			}
+		}
+		WHEN("the Tokeniser is fed W3") {
+			auto lines = t.Feed("foo\rbar\rbaz\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 3);
+				REQUIRE(lines[0][0] == "foo");
+				REQUIRE(lines[0][1] == "bar");
+				REQUIRE(lines[0][2] == "baz");
+			}
+		}
+		WHEN("the Tokeniser is fed W4") {
+			auto lines = t.Feed("silly windows\r\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 2);
+				REQUIRE(lines[0][0] == "silly");
+				REQUIRE(lines[0][1] == "windows");
+			}
+		}
+		WHEN("the Tokeniser is fed W5") {
+			auto lines = t.Feed("    abc def\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 2);
+				REQUIRE(lines[0][0] == "abc");
+				REQUIRE(lines[0][1] == "def");
+			}
+		}
+		WHEN("the Tokeniser is fed W6") {
+			auto lines = t.Feed("ghi jkl    \n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 2);
+				REQUIRE(lines[0][0] == "ghi");
+				REQUIRE(lines[0][1] == "jkl");
+			}
+		}
+		WHEN("the Tokeniser is fed W7") {
+			auto lines = t.Feed("    mno pqr    \n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 2);
+				REQUIRE(lines[0][0] == "mno");
+				REQUIRE(lines[0][1] == "pqr");
+			}
+		}
+		WHEN("the Tokeniser is fed Q1") {
+			auto lines = t.Feed("abc\\\ndef\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 1);
+				REQUIRE(lines[0][0] == "abc\ndef");
+			}
+		}
+		WHEN("the Tokeniser is fed Q2") {
+			auto lines = t.Feed("\"abc\ndef\"\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 1);
+				REQUIRE(lines[0][0] == "abc\ndef");
+			}
+		}
+		WHEN("the Tokeniser is fed Q3") {
+			auto lines = t.Feed("\"abc\\\ndef\"\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 1);
+				REQUIRE(lines[0][0] == "abc\ndef");
+			}
+		}
+		WHEN("the Tokeniser is fed Q4") {
+			auto lines = t.Feed("'abc\ndef'\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 1);
+				REQUIRE(lines[0][0] == "abc\ndef");
+			}
+		}
+		WHEN("the Tokeniser is fed Q5") {
+			auto lines = t.Feed("'abc\\\ndef'\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 1);
+				REQUIRE(lines[0][0] == "abc\\\ndef");
+			}
+		}
+		WHEN("the Tokeniser is fed Q6") {
+			auto lines = t.Feed("Scare\\\" quotes\\\"\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 2);
+				REQUIRE(lines[0][0] == "Scare\"");
+				REQUIRE(lines[0][1] == "quotes\"");
+			}
+		}
+		WHEN("the Tokeniser is fed Q7") {
+			auto lines = t.Feed("I\\'m free\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 2);
+				REQUIRE(lines[0][0] == "I'm");
+				REQUIRE(lines[0][1] == "free");
+			}
+		}
+		WHEN("the Tokeniser is fed Q8") {
+			auto lines = t.Feed("'hello, I'\\''m an escaped single quote'\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 1);
+				REQUIRE(lines[0][0] == "hello, I'm an escaped single quote");
+			}
+		}
+		WHEN("the Tokeniser is fed Q9") {
+			auto lines = t.Feed("\"hello, this is an \\\" escaped double quote\"\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 1);
+				REQUIRE(lines[0][0] == "hello, this is an \" escaped double quote");
+			}
+		}
+		WHEN("the Tokeniser is fed M1") {
+			auto lines = t.Feed("first line\nsecond line\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 2);
+				REQUIRE(lines[0].size() == 2);
+				REQUIRE(lines[0][0] == "first");
+				REQUIRE(lines[0][1] == "line");
+				REQUIRE(lines[1].size() == 2);
+				REQUIRE(lines[1][0] == "second");
+				REQUIRE(lines[1][1] == "line");
+			}
+		}
+		WHEN("the Tokeniser is fed U1") {
+			auto lines = t.Feed("北野 武\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 2);
+				REQUIRE(lines[0][0] == "北野");
+				REQUIRE(lines[0][1] == "武");
+			}
+		}
+		WHEN("the Tokeniser is fed U2") {
+			auto lines = t.Feed("f\xfcr\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 1);
+				REQUIRE(lines[0].size() == 1);
+				REQUIRE(lines[0][0] == "f\xef\xbf\xbdr");
+			}
+		}
+		WHEN("the Tokeniser is fed X1") {
+			auto lines = t.Feed("enqueue file \"C:\\\\Users\\\\Test\\\\Artist - Title.mp3\" 1\"\n");
+			THEN ("the Tokeniser returns the specified result") {
+				REQUIRE(lines.size() == 0);
+				REQUIRE(lines[0].size() == 4);
+				REQUIRE(lines[0][0] == "enqueue");
+				REQUIRE(lines[0][1] == "file");
+				REQUIRE(lines[0][2] == "C:\\Users\\Test\\Artist - Title.mp3");
+				REQUIRE(lines[0][3] == "1");
+			}
+		}
+	}
+}

--- a/src/tests/tokeniser.cpp
+++ b/src/tests/tokeniser.cpp
@@ -404,16 +404,6 @@ SCENARIO("Tokeniser is compliant with the BAPS3 spec", "[tokeniser][spec]") {
 				REQUIRE(lines[0][1] == "武");
 			}
 		}
-		// We don't implement UTF-8 replacement.
-		// Frankly, this should probably be removed from the spec tests.
-		//WHEN("the Tokeniser is fed U2") {
-		//	auto lines = t.Feed("f\xfcr\n");
-		//	THEN ("the Tokeniser returns the specified result") {
-		//		REQUIRE(lines.size() == 1);
-		//		REQUIRE(lines[0].size() == 1);
-		//		REQUIRE(lines[0][0] == "f\xef\xbf\xbdr");
-		//	}
-		//}
 		WHEN("the Tokeniser is fed X1") {
 			auto lines = t.Feed("enqueue file \"C:\\\\Users\\\\Test\\\\Artist - Title.mp3\" 1\n");
 			THEN ("the Tokeniser returns the specified result") {

--- a/src/tokeniser.cpp
+++ b/src/tokeniser.cpp
@@ -17,7 +17,7 @@
 #include "tokeniser.hpp"
 
 Tokeniser::Tokeniser()
-    : quote_type(Tokeniser::QuoteType::NONE)
+    : escape_next(false), in_word(false), quote_type(Tokeniser::QuoteType::NONE)
 {
 }
 

--- a/src/tokeniser.cpp
+++ b/src/tokeniser.cpp
@@ -17,7 +17,7 @@
 #include "tokeniser.hpp"
 
 Tokeniser::Tokeniser()
-    : escape_next(false), quote_type(Tokeniser::QuoteType::NONE)
+    : quote_type(Tokeniser::QuoteType::NONE)
 {
 }
 
@@ -65,11 +65,13 @@ std::vector<std::vector<std::string>> Tokeniser::Feed(const std::string &raw)
 						break;
 
 					case '\'':
+						this->in_word = true;
 						this->quote_type =
 						        QuoteType::SINGLE;
 						break;
 
 					case '\"':
+						this->in_word = true;
 						this->quote_type =
 						        QuoteType::DOUBLE;
 						break;
@@ -97,6 +99,7 @@ void Tokeniser::Push(const char c)
 {
 	assert(this->escape_next ||
 	       !(this->quote_type == QuoteType::NONE && isspace(c)));
+	this->in_word = true;
 	this->current_word.push_back(c);
 	this->escape_next = false;
 	assert(!this->current_word.empty());
@@ -104,8 +107,9 @@ void Tokeniser::Push(const char c)
 
 void Tokeniser::EndWord()
 {
-	// Ignore consecutive runs of whitespace.
-	if (this->current_word.empty()) return;
+	// Don't add a word unless we're in one.
+	if (!this->in_word) return;
+	this->in_word = false;
 
 	this->words.push_back(this->current_word);
 

--- a/src/tokeniser.hpp
+++ b/src/tokeniser.hpp
@@ -58,7 +58,10 @@ private:
 
 	/// Whether the next character is to be interpreted as an escape code.
 	/// This usually gets set to true when a backslash is detected.
-	bool escape_next;
+	bool escape_next = false;
+
+	/// Whether the tokeniser is currently in a word.
+	bool in_word = false;
 
 	/// The type of quotation currently being used in this Tokeniser.
 	QuoteType quote_type;

--- a/src/tokeniser.hpp
+++ b/src/tokeniser.hpp
@@ -58,10 +58,10 @@ private:
 
 	/// Whether the next character is to be interpreted as an escape code.
 	/// This usually gets set to true when a backslash is detected.
-	bool escape_next = false;
+	bool escape_next;
 
 	/// Whether the tokeniser is currently in a word.
-	bool in_word = false;
+	bool in_word;
 
 	/// The type of quotation currently being used in this Tokeniser.
 	QuoteType quote_type;


### PR DESCRIPTION
This imports the spec torture tests for the tokeniser, and also fixes the empty-string behaviour so that `''` and `""` are regarded as words.

Things that need to be done:
* [x] Decide what to do about `U2`.  I don't think we want to implement this behaviour in playd, so we need to decide whether to bin it from the spec tests or not.
* [x] Update the spec link to point to the new location of the spec tests.
* [x] Possibly clean up the tests a bit?