### PR TITLE
Update playd for VS2015; fix some build bugs.

### DIFF
--- a/README.VisualStudio.md
+++ b/README.VisualStudio.md
@@ -2,10 +2,13 @@
 
 Here are some field notes for building `playd` with Microsoft Visual Studio.
 
+**NOTE**: Much of this is from memory and is in need of filling out with
+more details.
+
 ## Visual Studio Versions
 
-At time of writing, `playd` has been tested with Visual Studio 2013 (version
-12).  As `playd` needs a C++11 compiler, earlier versions will likely fail;
+At time of writing, `playd` has been tested with Visual Studio 2015 (version
+14).  As `playd` needs a C++11 compiler, earlier versions will likely fail;
 newer versions may work, but this is not guaranteed.
 
 ## Assembling Libraries and Includes
@@ -16,18 +19,19 @@ the `lib` and `include` subdirectories respectively.
 
 The `lib` directory should include:
 
-* `libsox.lib`, from building libuv _as a shared library_ (see below);
+* `libmpg123-0.lib`, from building libmpg123 (details TBA);
+* `libsndfile-1.lib`, from the libsndfile Windows distribution;
 * `libuv.lib`, from building libuv as below;
-* `portaudio_x86.lib`, from building PortAudio from `cmake` as below;
-* `portaudiocpp-vc7_1-d.lib`, from building the PortAudio C++ bindings as
-  instructed below.
+* `SDL2.lib` and `SDLmain.lib` from SDL2 (if you are building a `Debug` version
+  of playd, you **will** need to build SDL2 from source--the Visual Studio
+  pre-packaged lib is built for `Release` only and **will** give you linker
+  errors!)
 
 The `include` directory should include:
 
-* `portaudio.h` from PortAudio's `include` directory;
-* The `portaudiocpp` directory (the _whole directory_, _not_ its contents) from
-  PortAudio's `bindings\cpp\include` directory;
-* `sox.h` from libsox's `src` directory;
+* `mpg123.h` from libmpg123;
+* The contents of SDL2's `include` directory (better safe than sorry);
+* `sndfile.h` and `sndfile.hh` from libsndfile;
 * These headers from libuv's `include` directory:
   * `tree.h`
   * `uv.h`
@@ -36,66 +40,7 @@ The `include` directory should include:
   * `uv-version.h`
   * `uv-win.h`
 
-## PortAudio
-
-Use cmake, and the shared library (`portaudio-x86.lib`).
-
-The C++ bindings are _not_ built by the cmake-generated Visual Studio
-solution.  However, the Visual Studio 7.1 solution in
-`bindings\cpp\build\vc7_1\static_library.sln` should work once upgraded to
-modern Visual Studio.
-
 ## LibUV
 
 This _must_ be built as a shared library (`vcbuild.bat shared`).  Otherwise,
 this should work fine.
-
-## SoX
-
-One of the authors, at the time of writing, maintain a [fork] of SoX with a
-VS2013 solution set up for building a dynamic DLL and import library.  This
-also contains any patches that we've applied to SoX to get it working for us. 
-
-Note that SoX itself requires several libraries to be placed in the directory
-one level above its root directory to compile; see the Visual Studio project's
-includes for details.
-
-### Stable SoX
-
-Some persuasion of the dated sources recommended by the SoX build instructions
-is necessary to get them to build with modern Visual Studio.  The following
-'hacks' work on 32-bit VS2013:
-
-* libflac: Replace all `ftello`/`fseeko` with `ftell`/`fseek`;
-* libsndfile: Replace all lrint with _lrint.
-* In the LibSox project, change the following properties:
-  * __General/General/Target Extension__ to __.dll__;
-  * __General/Project Defaults/Configuration Type__ to
-    __Dynamic Library (.dll)__;
-  * __Linker/Input/Additional Dependencies__ should contain:
-    * `winmm.lib`
-    * `libflac.lib`
-    * `libgsm.lib`
-    * `libid3tag.lib`
-    * `liblpc10.lib`
-    * `libmad.lib`
-    * `libmp3lame.lib`
-    * `libogg.lib`
-    * `libpng.lib`
-    * `libsndfileg72x.lib`
-    * `libsndfile-1.lib`
-    * `libsndfilegsm610.lib`
-    * `libspeex.lib`
-    * `libvorbis.lib`
-    * `libwavpack.lib`
-    * `libzlib.lib`
-  * __Linker/Input/Module Definition File__ should point to a valid module
-    definition file (see below);
-  * __Linker/General/Link Library Dependencies__ may need to be set to __No__.
-
-### Module definition file
-
-This is needed to make LibSoX build a `.lib` file for dynamic linking.  An
-example is given in the source bundle as `libsox.def`.
-
-[fork]: https://github.com/CaptainHayashi/sox

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="sdl2" version="2.0.3" targetFramework="Native" />
-  <package id="sdl2.redist" version="2.0.3" targetFramework="Native" />
-</packages>

--- a/playd.vcxproj
+++ b/playd.vcxproj
@@ -103,7 +103,7 @@
 				%(AdditionalLibraryDirectories)
 			</AdditionalLibraryDirectories>
       <AdditionalDependencies>Ws2_32.lib;libsndfile-1.lib;libmpg123-0.lib;libuv.lib;SDL2.lib;SDL2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <ShowProgress>LinkVerboseLib</ShowProgress>
+      <ShowProgress>NotSet</ShowProgress>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/playd.vcxproj
+++ b/playd.vcxproj
@@ -1,162 +1,138 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="Debug|Win32">
-			<Configuration>Debug</Configuration>
-			<Platform>Win32</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Release|Win32">
-			<Configuration>Release</Configuration>
-			<Platform>Win32</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="src\audio\audio.cpp" />
-		<ClCompile Include="src\audio\audio_sink.cpp" />
-		<ClCompile Include="src\audio\audio_source.cpp" />
-		<ClCompile Include="src\audio\audio_system.cpp" />
-		<ClCompile Include="src\audio\ringbuffer.cpp" />
-		<ClCompile Include="src\audio\sample_formats.cpp" />
-		<ClCompile Include="src\audio\sources\flac.cpp" />
-		<ClCompile Include="src\audio\sources\mp3.cpp" />
-		<ClCompile Include="src\audio\sources\sndfile.cpp" />
-		<ClCompile Include="src\cmd.cpp" />
-		<ClCompile Include="src\cmd_result.cpp" />
-		<ClCompile Include="src\contrib\pa_ringbuffer\pa_ringbuffer.c" />
-		<ClCompile Include="src\errors.cpp" />
-		<ClCompile Include="src\io\io_core.cpp" />
-		<ClCompile Include="src\io\io_response.cpp" />
-		<ClCompile Include="src\io\tokeniser.cpp" />
-		<ClCompile Include="src\main.cpp" />
-		<ClCompile Include="src\player\player.cpp" />
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="src\audio\audio.hpp" />
-		<ClInclude Include="src\audio\audio_sink.hpp" />
-		<ClInclude Include="src\audio\audio_source.hpp" />
-		<ClInclude Include="src\audio\audio_system.hpp" />
-		<ClInclude Include="src\audio\ringbuffer.hpp" />
-		<ClInclude Include="src\audio\sample_formats.hpp" />
-		<ClInclude Include="src\audio\sources\flac.hpp" />
-		<ClInclude Include="src\audio\sources\mp3.hpp" />
-		<ClInclude Include="src\audio\sources\sndfile.hpp" />
-		<ClInclude Include="src\cmd.hpp" />
-		<ClInclude Include="src\cmd_result.hpp" />
-		<ClInclude Include="src\contrib\pa_ringbuffer\pa_memorybarrier.h" />
-		<ClInclude Include="src\contrib\pa_ringbuffer\pa_ringbuffer.h" />
-		<ClInclude Include="src\errors.hpp" />
-		<ClInclude Include="src\io\io_core.hpp" />
-		<ClInclude Include="src\io\io_response.hpp" />
-		<ClInclude Include="src\io\tokeniser.hpp" />
-		<ClInclude Include="src\main.hpp" />
-		<ClInclude Include="src\messages.h" />
-		<ClInclude Include="src\player\player.hpp" />
-		<ClInclude Include="src\resource.h" />
-	</ItemGroup>
-	<ItemGroup>
-		<None Include="packages.config">
-			<SubType>Designer</SubType>
-		</None>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{625EC8F2-633C-4666-BC4B-25F6BECABA31}</ProjectGuid>
-		<Keyword>Win32Proj</Keyword>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>true</UseDebugLibraries>
-		<PlatformToolset>v120</PlatformToolset>
-		<UseOfMfc>false</UseOfMfc>
-		<CharacterSet>Unicode</CharacterSet>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<PlatformToolset>v120</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Label="UserMacros">
-		<NuGetPackageImportStamp>33725eb4</NuGetPackageImportStamp>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<ClCompile>
-			<PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;WITH_FLAC;WITH_MP3;WITH_SNDFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-			<WarningLevel>Level3</WarningLevel>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\audio\audio.cpp" />
+    <ClCompile Include="src\audio\audio_sink.cpp" />
+    <ClCompile Include="src\audio\audio_source.cpp" />
+    <ClCompile Include="src\audio\audio_system.cpp" />
+    <ClCompile Include="src\audio\ringbuffer.cpp" />
+    <ClCompile Include="src\audio\sample_formats.cpp" />
+    <ClCompile Include="src\audio\sources\mp3.cpp" />
+    <ClCompile Include="src\audio\sources\sndfile.cpp" />
+    <ClCompile Include="src\cmd_result.cpp" />
+    <ClCompile Include="src\contrib\pa_ringbuffer\pa_ringbuffer.c" />
+    <ClCompile Include="src\errors.cpp" />
+    <ClCompile Include="src\io.cpp" />
+    <ClCompile Include="src\main.cpp" />
+    <ClCompile Include="src\player.cpp" />
+    <ClCompile Include="src\response.cpp" />
+    <ClCompile Include="src\tokeniser.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\audio\audio.hpp" />
+    <ClInclude Include="src\audio\audio_sink.hpp" />
+    <ClInclude Include="src\audio\audio_source.hpp" />
+    <ClInclude Include="src\audio\audio_system.hpp" />
+    <ClInclude Include="src\audio\ringbuffer.hpp" />
+    <ClInclude Include="src\audio\sample_formats.hpp" />
+    <ClInclude Include="src\audio\sources\mp3.hpp" />
+    <ClInclude Include="src\audio\sources\sndfile.hpp" />
+    <ClInclude Include="src\cmd_result.hpp" />
+    <ClInclude Include="src\contrib\pa_ringbuffer\pa_memorybarrier.h" />
+    <ClInclude Include="src\contrib\pa_ringbuffer\pa_ringbuffer.h" />
+    <ClInclude Include="src\errors.hpp" />
+    <ClInclude Include="src\io.hpp" />
+    <ClInclude Include="src\main.hpp" />
+    <ClInclude Include="src\messages.h" />
+    <ClInclude Include="src\player.hpp" />
+    <ClInclude Include="src\resource.h" />
+    <ClInclude Include="src\response.hpp" />
+    <ClInclude Include="src\tokeniser.hpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{625EC8F2-633C-4666-BC4B-25F6BECABA31}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;WITH_FLAC;WITH_MP3;WITH_SNDFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>
 				include;
 				%(AdditionalIncludeDirectories)
 			</AdditionalIncludeDirectories>
-		</ClCompile>
-		<Link>
-			<TargetMachine>MachineX86</TargetMachine>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<SubSystem>Console</SubSystem>
-			<AdditionalLibraryDirectories>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>
 				lib;
 				%(AdditionalLibraryDirectories)
 			</AdditionalLibraryDirectories>
-			<AdditionalDependencies>Ws2_32.lib;
+      <AdditionalDependencies>Ws2_32.lib;libsndfile-1.lib;libmpg123-0.lib;libuv.lib;SDL2.lib;SDL2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ShowProgress>LinkVerboseLib</ShowProgress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;WITH_FLAC;WITH_MP3;WITH_SNDFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>
+				include;
+				%(AdditionalIncludeDirectories)
+			</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>
+				lib;
+				%(AdditionalLibraryDirectories)
+			</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Ws2_32.lib;
 				libsndfile-1.lib;
 				libFLAC++_dynamic.lib;
 				libmpg123-0.lib
 ;libuv.lib;%(AdditionalDependencies)</AdditionalDependencies>
-		</Link>
-	</ItemDefinitionGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-		<ClCompile>
-			<PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;WITH_FLAC;WITH_MP3;WITH_SNDFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-			<WarningLevel>Level3</WarningLevel>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>
-				include;
-				%(AdditionalIncludeDirectories)
-			</AdditionalIncludeDirectories>
-		</ClCompile>
-		<Link>
-			<TargetMachine>MachineX86</TargetMachine>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<SubSystem>Console</SubSystem>
-			<AdditionalLibraryDirectories>
-				lib;
-				%(AdditionalLibraryDirectories)
-			</AdditionalLibraryDirectories>
-			<AdditionalDependencies>Ws2_32.lib;
-				libsndfile-1.lib;
-				libFLAC++_dynamic.lib;
-				libmpg123-0.lib
-;libuv.lib;%(AdditionalDependencies)</AdditionalDependencies>
-		</Link>
-	</ItemDefinitionGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets">
-		<Import Project="packages\sdl2.redist.2.0.3\build\native\sdl2.redist.targets" Condition="Exists('packages\sdl2.redist.2.0.3\build\native\sdl2.redist.targets')" />
-		<Import Project="packages\sdl2.2.0.3\build\native\sdl2.targets" Condition="Exists('packages\sdl2.2.0.3\build\native\sdl2.targets')" />
-	</ImportGroup>
-	<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-		<PropertyGroup>
-			<ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-		</PropertyGroup>
-		<Error Condition="!Exists('packages\sdl2.redist.2.0.3\build\native\sdl2.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.redist.2.0.3\build\native\sdl2.redist.targets'))" />
-		<Error Condition="!Exists('packages\sdl2.2.0.3\build\native\sdl2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.2.0.3\build\native\sdl2.targets'))" />
-	</Target>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>


### PR DESCRIPTION
This basically does the following:

* Converts the `vcxproj` to VS2015;
* Strips out the SDL2 nuget package, because for Debug builds one has to build their own SDL2 (and this is fairly easy!);
* Adds manual requirements for `SDL2.lib` and `SDL2Main.lib` in the library files set;
* Slightly updates the build notes to reference the correct libraries (portaudio?  sox?  really!?).