### PR TITLE
Disable appveyor until the script is fixed.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,11 @@
 #
 #-----------------------------------------------------------------------------
 
+# Disable builds until this script is fixed
+branches:
+  only:
+    - fix-appveyor
+
 # Operating system (build VM template)
 os: Visual Studio 2015
 


### PR DESCRIPTION
Appveyor hasn't been running because the auth token expired, but of course it's not working anyway because we need VS2017+.